### PR TITLE
Support for new ayon addon structure

### DIFF
--- a/package.py
+++ b/package.py
@@ -1,0 +1,2 @@
+name = "kitsu"
+version = "1.0.2"

--- a/server/__init__.py
+++ b/server/__init__.py
@@ -1,6 +1,5 @@
 from typing import Type
 
-# from fastapi import BackgroundTasks
 from ayon_server.addons import BaseServerAddon
 from ayon_server.api.dependencies import CurrentUser
 from ayon_server.api.responses import EmptyResponse
@@ -12,7 +11,13 @@ from .kitsu.init_pairing import InitPairingRequest, init_pairing, sync_request
 from .kitsu.pairing_list import PairingItemModel, get_pairing_list
 from .kitsu.push import PushEntitiesRequestModel, push_entities
 from .settings import DEFAULT_VALUES, KitsuSettings
-from .version import __version__
+
+try:
+    from .version import __version__
+except ModuleNotFoundError:
+    # temporary solution for local development
+    # version is pushed from package.py in ayon >= 1.0.3
+    __version__ = "0.0.0"
 
 #
 # Events:


### PR DESCRIPTION
While this addon still uses the original addon structure in create_package.py, 
this PR adds a simple way how to develop the addon directly on the server (with ayon >1.0.3).

Just:
-  clone the repository so the structure will match: `ayon-docker/addons/kitsu/dev/package.py`
- in the repo (dev) create a frontend symlink (`ln -s server/frontend frontend`)
- add `+git` to service makefile's dev target if needed:

`--env AYON_ADDON_VERSION=$(AYON_ADDON_VERSION)+git \`
