### PR TITLE
Use family naming in note filtering

### DIFF
--- a/client/ayon_kitsu/plugins/publish/integrate_kitsu_note.py
+++ b/client/ayon_kitsu/plugins/publish/integrate_kitsu_note.py
@@ -49,6 +49,16 @@ class IntegrateKitsuNote(pyblish.api.ContextPlugin):
         return re.sub(pattern, replace_missing_key, template)
 
     def process(self, context):
+        # Backwards compatibility for wront key
+        if "product_type_requirements" in self.status_change_conditions:
+            family_requirements = self.status_change_conditions[
+                "product_type_requirements"
+            ]
+        else:
+            family_requirements = self.status_change_conditions[
+                "family_requirements"
+            ]
+
         for instance in context:
             # Check if instance is a review by checking its family
             # Allow a match to primary family or any of families
@@ -87,9 +97,8 @@ class IntegrateKitsuNote(pyblish.api.ContextPlugin):
                 }
 
                 # Check if any family requirement is met
-                for family_requirement in self.status_change_conditions[
-                    "family_requirements"
-                ]:
+
+                for family_requirement in family_requirements:
                     condition = family_requirement["condition"] == "equal"
 
                     for family in families:

--- a/server/settings/defaults.py
+++ b/server/settings/defaults.py
@@ -6,7 +6,7 @@ DEFAULT_VALUES = {
             "note_status_shortname": "wfa",
             "status_change_conditions": {
                 "status_conditions": [],
-                "product_type_requirements": [],
+                "family_requirements": [],
             },
             "custom_comment_template": {
                 "enabled": False,

--- a/server/settings/settings.py
+++ b/server/settings/settings.py
@@ -23,19 +23,19 @@ class StatusChangeCondition(BaseSettingsModel):
     short_name: str = Field("", title="Short name")
 
 
-class StatusChangeProductTypeRequirementModel(BaseSettingsModel):
+class StatusChangeFamilyRequirementModel(BaseSettingsModel):
     condition: str = Field(
         "equal", enum_resolver=_status_change_cond_enum, title="Condition"
     )
-    product_type: str = Field("", title="Product type")
+    product_type: str = Field("", title="Family")
 
 
 class StatusChangeConditionsModel(BaseSettingsModel):
     status_conditions: list[StatusChangeCondition] = Field(
         default_factory=list, title="Status conditions"
     )
-    family_requirements: list[StatusChangeProductTypeRequirementModel] = Field(
-        default_factory=list, title="Product type requirements"
+    family_requirements: list[StatusChangeFamilyRequirementModel] = Field(
+        default_factory=list, title="Family requirements"
     )
 
 

--- a/server/settings/settings.py
+++ b/server/settings/settings.py
@@ -34,7 +34,7 @@ class StatusChangeConditionsModel(BaseSettingsModel):
     status_conditions: list[StatusChangeCondition] = Field(
         default_factory=list, title="Status conditions"
     )
-    product_type_requirements: list[StatusChangeProductTypeRequirementModel] = Field(
+    family_requirements: list[StatusChangeProductTypeRequirementModel] = Field(
         default_factory=list, title="Product type requirements"
     )
 


### PR DESCRIPTION
## Description
Settings attribute `product_type_requirements` was changed to `family_requirements`. If is not filter of product type but all instance families thus it should have family naming.