### PR TITLE
Add revision nr to add_preview from publish version

### DIFF
--- a/client/ayon_kitsu/plugins/publish/integrate_kitsu_review.py
+++ b/client/ayon_kitsu/plugins/publish/integrate_kitsu_review.py
@@ -16,7 +16,7 @@ class IntegrateKitsuReview(pyblish.api.InstancePlugin):
         comment_id = instance.data.get("kitsuComment", {}).get("id")
         if not comment_id:
             self.log.debug(
-                "Comment not created, review not pushed to preview."
+                "Comment not created, review not pushed to preview.",
             )
             return
 
@@ -35,6 +35,10 @@ class IntegrateKitsuReview(pyblish.api.InstancePlugin):
             self.log.debug("Found review at: {}".format(review_path))
 
             gazu.task.add_preview(
-                task_id, comment_id, review_path, normalize_movie=True
+                task=task_id,
+                comment=comment_id,
+                preview_file_path=review_path,
+                normalize_movie=True,
+                revision=instance.data["version"],
             )
             self.log.info("Review upload on comment")


### PR DESCRIPTION
This PR adds the publish version as the revision version in Kitsu. This way the version in Kitsu and Ayon will always reflect each other.