### PR TITLE
Enhancement/comment template

### DIFF
--- a/server/settings/defaults.py
+++ b/server/settings/defaults.py
@@ -18,8 +18,8 @@ DEFAULT_VALUES = {
 
 |  |  |
 |--|--|
-| version| `{version}` |
-| product type | `{product[type]}` |
+| version | `{version}` |
+| family | `{family}` |
 | name | `{name}` |""",
             },
         }

--- a/server/settings/defaults.py
+++ b/server/settings/defaults.py
@@ -14,7 +14,13 @@ DEFAULT_VALUES = {
             },
             "custom_comment_template": {
                 "enabled": False,
-                "comment_template": "{comment}\n\n|  |  |\n|--|--|\n| version| `{version}` |\n| product type | `{product[type]}` |\n| name | `{name}` |",
+                "comment_template": """{comment}
+
+|  |  |
+|--|--|
+| version| `{version}` |
+| product type | `{product[type]}` |
+| name | `{name}` |""",
             },
         }
     },

--- a/server/settings/settings.py
+++ b/server/settings/settings.py
@@ -54,7 +54,7 @@ class CustomCommentTemplateModel(BaseSettingsModel):
     """
 
     enabled: bool = Field(True)
-    comment_template: str = Field("", title="Custom comment")
+    comment_template: str = Field("", widget="textarea", title="Custom comment")
 
 
 class IntegrateKitsuNotes(BaseSettingsModel):


### PR DESCRIPTION
Make the Kitsu comment template a multiline textarea so that markdown table can be supported. 
Make the default a multiline text too.
![Screenshot 2024-03-15 at 19 31 39](https://github.com/ynput/ayon-kitsu/assets/1951220/26158b41-6763-4b0a-ab5e-17e5d10e1d1d)

swap `product[name]` for `family` in the template as product[name] in my tests.

This translates to a kitsu comment:
![Screenshot 2024-03-15 at 19 34 23](https://github.com/ynput/ayon-kitsu/assets/1951220/26878c4c-5a47-4c8f-84b6-7ee0b0be431d)

This PR requires  #33 or the settings will not work.
This PR is compatible with #35 