### PR TITLE
Catch empty strings in calculate_end_frame()

### DIFF
--- a/server/kitsu/utils.py
+++ b/server/kitsu/utils.py
@@ -16,15 +16,15 @@ def calculate_end_frame(
     entity_dict: dict[str, int], folder: FolderEntity
 ) -> int | None:
     # Calculate the end-frame
-    if entity_dict.get("nb_frames") and not entity_dict["data"].get("frame_out"):
-        frame_start = entity_dict["data"].get("frame_in")
+    if entity_dict.get("nb_frames") and entity_dict["data"].get("frame_out", "") != "":
+        frame_start = entity_dict["data"].get("frame_in", "")
         # If kitsu doesn't have a frame in, get it from the folder in Ayon
-        if frame_start is None or frame_start == "":
+        if frame_start == "":
             for key, value in folder.attrib:
                 if key == "frameStart":
                     frame_start = value
                     break
-        if frame_start is not None and frame_start != "":
+        if frame_start != "":
             return frame_start + entity_dict["nb_frames"]
 
 

--- a/server/kitsu/utils.py
+++ b/server/kitsu/utils.py
@@ -19,12 +19,12 @@ def calculate_end_frame(
     if entity_dict.get("nb_frames") and not entity_dict["data"].get("frame_out"):
         frame_start = entity_dict["data"].get("frame_in")
         # If kitsu doesn't have a frame in, get it from the folder in Ayon
-        if frame_start is None:
+        if frame_start is None or frame_start == "":
             for key, value in folder.attrib:
                 if key == "frameStart":
                     frame_start = value
                     break
-        if frame_start is not None:
+        if frame_start is not None and frame_start != "":
             return frame_start + entity_dict["nb_frames"]
 
 


### PR DESCRIPTION
This PR simply adds a check for empty strings in `calculate_end_frame()` instead of only None

If the Kitsu task have the metadata frame_in or frame_out but it doesn't have a set value in Kitsu it will return an empty string.
Without this fix the sync will catch an error as frame_start will be found but you can't combine an empty string with nb_frames.