### PR TITLE
Manage script: Docker build uses full path to docker file

### DIFF
--- a/services/manage.ps1
+++ b/services/manage.ps1
@@ -47,7 +47,7 @@ function run {
 }
 
 function build {
-  & docker build -t "$IMAGE" -f $(SERVICE)/Dockerfile .
+  & docker build -t "$IMAGE" -f "$($script_dir)/$($SERVICE)/Dockerfile" .
 }
 
 function clean {


### PR DESCRIPTION
## Description
Use full path to dockerfile in build command so it is not necessary to run it from specific directory.