### PR TITLE
Sync: Convert frame attribute from kitsu into integer

### DIFF
--- a/server/kitsu/utils.py
+++ b/server/kitsu/utils.py
@@ -16,16 +16,24 @@ def calculate_end_frame(
     entity_dict: dict[str, int], folder: FolderEntity
 ) -> int | None:
     # Calculate the end-frame
-    if entity_dict.get("nb_frames") and entity_dict["data"].get("frame_out", "") != "":
-        frame_start = entity_dict["data"].get("frame_in", "")
-        # If kitsu doesn't have a frame in, get it from the folder in Ayon
-        if frame_start == "":
-            for key, value in folder.attrib:
-                if key == "frameStart":
-                    frame_start = value
-                    break
-        if frame_start != "":
-            return frame_start + entity_dict["nb_frames"]
+    nb_frames = entity_dict.get("nb_frames")
+
+    # NOTE: 'frame_out' and 'frame_in' values are stores as strings
+    if not nb_frames or not entity_dict["data"].get("frame_out"):
+        return
+
+    frame_start = entity_dict["data"].get("frame_in", "")
+    if frame_start:
+        frame_start = int(frame_start)
+    else:
+        # If kitsu doesn't have a frame in, get it from the folder in AYON
+        for key, value in folder.attrib:
+            if key == "frameStart":
+                frame_start = value
+                break
+
+    if frame_start:
+        return frame_start + entity_dict["nb_frames"]
 
 
 def remove_accents(input_str: str) -> str:


### PR DESCRIPTION
## Description
Extend fix from https://github.com/ynput/ayon-kitsu/pull/40 . The value of `"frame_in"` is string but was not converted to integer so it crashed on `frame_start + entity_dict["nb_frames"]` because it tried to concatenat `str` with `int`.