### PR TITLE
Remove one frame when calculating end frame with nb_frames

### DIFF
--- a/server/kitsu/utils.py
+++ b/server/kitsu/utils.py
@@ -33,7 +33,8 @@ def calculate_end_frame(
                 break
 
     if frame_start:
-        return frame_start + entity_dict["nb_frames"]
+        # Remove one frame as the frame_start frame is the one frame
+        return frame_start + nb_frames - 1
 
 
 def remove_accents(input_str: str) -> str:


### PR DESCRIPTION
Currently the syncing adds one extra frame to the frame_end as the first frame gets calculated twice. Once in frame_start and then again in nb_frames.

This PR fixes this.

To try the fix: Create a shot in Kitsu. Set the length of the clip. Sync to Ayon and check that it's using the same amount of frames.