### PR TITLE
Bugfix: Split subprocess output by lines

### DIFF
--- a/create_package.py
+++ b/create_package.py
@@ -192,7 +192,7 @@ def _get_yarn_executable():
     if platform.system().lower() == "windows":
         cmd = "where"
 
-    for line in subprocess.check_output([cmd, "yarn"], encoding="utf-8").split():
+    for line in subprocess.check_output([cmd, "yarn"], encoding="utf-8").splitlines():
         if not line or not os.path.exists(line):
             continue
         try:


### PR DESCRIPTION
## Changelog Description
 Subprocess output should be split by lines not by regular split.
 `where yarn` in windows can include spaces if user has yarn installed in user directory and user names can include spaces.