### PR TITLE
Get the project by ID instead of name

### DIFF
--- a/client/ayon_kitsu/plugins/publish/collect_kitsu_entities.py
+++ b/client/ayon_kitsu/plugins/publish/collect_kitsu_entities.py
@@ -12,9 +12,11 @@ class CollectKitsuEntities(pyblish.api.ContextPlugin):
     label = "Kitsu entities"
 
     def process(self, context):
-        kitsu_project = gazu.project.get_project(
-            context.data["projectEntity"]["data"]["kitsuProjectId"]
-        )
+        project_entity = context.data["projectEntity"]
+        project_id = project_entity["data"].get("kitsuProjectId")
+        kitsu_project = None
+        if project_id:
+            kitsu_project = gazu.project.get_project(project_id)
         if not kitsu_project:
             project_name = context.data["projectName"]
             raise KnownPublishError(

--- a/client/ayon_kitsu/plugins/publish/collect_kitsu_entities.py
+++ b/client/ayon_kitsu/plugins/publish/collect_kitsu_entities.py
@@ -13,7 +13,9 @@ class CollectKitsuEntities(pyblish.api.ContextPlugin):
 
     def process(self, context):
         project_name = context.data["projectName"]
-        kitsu_project = gazu.project.get_project_by_name(project_name)
+        kitsu_project = gazu.project.get_project(
+            context.data["projectEntity"]["data"]["kitsuProjectId"]
+        )
         if not kitsu_project:
             raise KnownPublishError(
                 f"Project '{project_name}' not found in kitsu!"

--- a/client/ayon_kitsu/plugins/publish/collect_kitsu_entities.py
+++ b/client/ayon_kitsu/plugins/publish/collect_kitsu_entities.py
@@ -12,11 +12,11 @@ class CollectKitsuEntities(pyblish.api.ContextPlugin):
     label = "Kitsu entities"
 
     def process(self, context):
-        project_name = context.data["projectName"]
         kitsu_project = gazu.project.get_project(
             context.data["projectEntity"]["data"]["kitsuProjectId"]
         )
         if not kitsu_project:
+            project_name = context.data["projectName"]
             raise KnownPublishError(
                 f"Project '{project_name}' not found in kitsu!"
             )

--- a/client/ayon_kitsu/plugins/publish/collect_kitsu_entities.py
+++ b/client/ayon_kitsu/plugins/publish/collect_kitsu_entities.py
@@ -18,7 +18,7 @@ class CollectKitsuEntities(pyblish.api.ContextPlugin):
         if not kitsu_project:
             project_name = context.data["projectName"]
             raise KnownPublishError(
-                f"Project '{project_name}' not found in kitsu!"
+                f"Project '{project_name}' not found in kitsu by id!"
             )
 
         context.data["kitsuProject"] = kitsu_project


### PR DESCRIPTION
Originally we fetched the project from Kitsu by its name. Some times the name in Ayon doesn't match the name in Kitsu.
This PR fixes so we fetch the project by the KitsuProjectID instead.

To try this PR simply try and publish a preview to Kitsu.