### PR TITLE
Enhancement/check and test for skipping Kitsu bot users

### DIFF
--- a/server/kitsu/push.py
+++ b/server/kitsu/push.py
@@ -225,6 +225,14 @@ async def sync_person(
 ):
     logging.info("sync_person")
 
+    # == check should Person entity be synced ==
+    # do not sync Kitsu API bots
+    if entity_dict.get("is_bot"):
+        logging.info(
+            f"skipping sync_person for Kitsu Bot: {entity_dict.get('first_name')} {entity_dict.get('last_name')}"
+        )
+        return
+
     username = remove_accents(
         f"{entity_dict['first_name']}.{entity_dict['last_name']}".lower().strip()
     )

--- a/tests/tests/fixtures.py
+++ b/tests/tests/fixtures.py
@@ -126,3 +126,55 @@ def processor(kitsu_url):
             return PROJECT_NAME
 
     return MockProcessor()
+
+
+# ======= Studio Settings Fixtures ==========
+
+
+@pytest.fixture()
+def users_enabled(api, kitsu_url):
+    """update kitsu addon settings.sync_settings.sync_users.enabled"""
+    # lets get the settings for the addon
+    res = api.get(f"{kitsu_url}/settings")
+    assert res.status_code == 200
+    settings = res.data
+
+    # get original values
+    users_enabled = settings["sync_settings"]["sync_users"]["enabled"]
+
+    # set settings for tests
+    if not users_enabled:
+        settings["sync_settings"]["sync_users"]["enabled"] = True
+        res = api.post(f"{kitsu_url}/settings", **settings)
+
+    yield
+
+    # set settings back to orginal values
+    if not users_enabled:
+        settings["sync_settings"]["sync_users"]["enabled"] = users_enabled
+        res = api.post(f"{kitsu_url}/settings", **settings)
+
+
+@pytest.fixture()
+def users_disabled(api, kitsu_url):
+    """update kitsu addon settings.sync_settings.sync_users.enabled"""
+    # lets get the settings for the addon
+    res = api.get(f"{kitsu_url}/settings")
+    assert res.status_code == 200
+    settings = res.data
+
+    # get original values
+    value = settings["sync_settings"]["sync_users"]["enabled"]
+    print(f"users_disabled: {value}")
+
+    # set settings for tests
+    if value:
+        settings["sync_settings"]["sync_users"]["enabled"] = False
+        res = api.post(f"{kitsu_url}/settings", **settings)
+
+    yield
+
+    # set settings back to orginal values
+    if value:
+        settings["sync_settings"]["sync_users"]["enabled"] = value
+        res = api.post(f"{kitsu_url}/settings", **settings)

--- a/tests/tests/test_push_person.py
+++ b/tests/tests/test_push_person.py
@@ -1,0 +1,73 @@
+"""tests for endpoint 'api/addons/kitsu/{version}/push'
+with entities of kitsu type: Person
+
+$ poetry run pytest tests/test_push_person.py
+"""
+
+from pprint import pprint
+
+import pytest
+
+from .fixtures import PROJECT_NAME, api, kitsu_url, users_enabled
+
+
+def test_push_bot(api, kitsu_url, users_enabled):
+    """test for new API token feature in Kitsu 0.19.2 - Person where is_bot=True"""
+
+    # ensure user is deleted
+    api.delete("/users/test.bot")
+
+    bot = {
+        "is_bot": True,
+        "first_name": "Test",
+        "last_name": "Bot",
+        "email": "test.bot@studio.com",
+        "phone": None,
+        "contract_type": "open-ended",
+        "active": True,
+        "archived": False,
+        "last_presence": None,
+        "desktop_login": None,
+        "login_failed_attemps": 0,
+        "last_login_failed": None,
+        "totp_enabled": False,
+        "email_otp_enabled": False,
+        "fido_enabled": False,
+        "preferred_two_factor_authentication": None,
+        "shotgun_id": None,
+        "timezone": "Europe/Paris",
+        "locale": "en_US",
+        "data": None,
+        "role": "admin",
+        "has_avatar": True,
+        "notifications_enabled": False,
+        "notifications_slack_enabled": False,
+        "notifications_slack_userid": "",
+        "notifications_mattermost_enabled": False,
+        "notifications_mattermost_userid": "",
+        "notifications_discord_enabled": False,
+        "notifications_discord_userid": "",
+        "expiration_date": "2024-04-30",
+        "is_generated_from_ldap": False,
+        "ldap_uid": None,
+        "full_name": "Test Bot",
+        "id": "bot-id-1",
+        "created_at": "2024-01-01T00:00:00",
+        "updated_at": "2024-01-01T00:00:00",
+        "type": "Person",
+        "fido_devices": [],
+    }
+
+    res = api.post(
+        f"{kitsu_url}/push",
+        project_name=PROJECT_NAME,
+        entities=[bot],
+    )
+    assert res.status_code == 200
+
+    with pytest.raises(Exception) as exc_info:
+        api.get_user("test.bot")
+
+    assert str(exc_info.value).startswith("404 Client Error: Not Found for url:")
+
+    api.delete("/users/test.bot")


### PR DESCRIPTION
Kitsu added Bot users to act as service users with api_keys. 
As they will not have assignments they can be skipped. 

It was discussed on discord [here](https://discord.com/channels/517362899170230292/563751989075378201/1214195504322187274)

```
cd tests
poetry run pytest tests/test_push_person.py
```