### PR TITLE
Tests/push_update

### DIFF
--- a/server/kitsu/utils.py
+++ b/server/kitsu/utils.py
@@ -14,26 +14,22 @@ from ayon_server.lib.postgres import Postgres
 def calculate_end_frame(
     entity_dict: dict[str, int], folder: FolderEntity
 ) -> int | None:
-    # Calculate the end-frame
-    nb_frames = entity_dict.get("nb_frames")
-
-    # NOTE: 'frame_out' and 'frame_in' values are stores as strings
-    if not nb_frames or not entity_dict["data"].get("frame_out"):
+    # for concepts data=None
+    if "data" not in entity_dict or not isinstance(entity_dict["data"], dict):
         return
 
-    frame_start = entity_dict["data"].get("frame_in", "")
-    if frame_start:
-        frame_start = int(frame_start)
-    else:
-        # If kitsu doesn't have a frame in, get it from the folder in AYON
-        for key, value in folder.attrib:
-            if key == "frameStart":
-                frame_start = value
-                break
+    # return end-frame if set
+    if entity_dict["data"].get("frame_out"):
+        return entity_dict["data"].get("frame_out")
 
-    if frame_start:
-        # Remove one frame as the frame_start frame is the one frame
-        return frame_start + nb_frames - 1
+    # Calculate the end-frame
+    if entity_dict.get("nb_frames") and not entity_dict["data"].get("frame_out"):
+        frame_start = entity_dict["data"].get("frame_in")
+        # If kitsu doesn't have a frame in, get it from the folder in Ayon
+        if frame_start is None and hasattr(folder.attrib, "frameStart"):
+            frame_start = folder.attrib.frameStart
+        if frame_start is not None:
+            return int(frame_start) + int(entity_dict["nb_frames"])
 
 
 def create_name_and_label(kitsu_name: str) -> dict[str, str]:

--- a/tests/tests/test_push_update.py
+++ b/tests/tests/test_push_update.py
@@ -86,7 +86,7 @@ def test_update_folder_no_changes(api, kitsu_url):
     assert res.status_code == 200
 
     # there should be no folders returned as none were created or updated
-    assert res.data == {"folders": {}, "tasks": {}}
+    assert res.data["folders"] == {}
 
 
 def test_update_task_status(api, kitsu_url):

--- a/tests/tests/test_push_update.py
+++ b/tests/tests/test_push_update.py
@@ -47,6 +47,55 @@ def test_update_folder_attrib(api, kitsu_url, init_data):
     assert folder["attrib"]["frameEnd"] == 102
 
 
+def test_calculate_frames(api, kitsu_url):
+    """test for utils.calculate_frames"""
+
+    # do a partial update
+    kitsu_id = "shot-id-1"
+    update = {
+        "id": kitsu_id,  # required
+        "type": "Shot",  # required
+        "name": "SH001",
+        "nb_frames": 200,  # change the number of frames
+        "data": {
+            "frame_in": "10",
+        },
+    }
+    res = api.post(
+        f"{kitsu_url}/push",
+        project_name=PROJECT_NAME,
+        entities=[update],
+    )
+    assert res.status_code == 200
+
+    # lets get the ayon folder
+    ayon_id = res.data["folders"][kitsu_id]
+    folder = api.get_folder_by_id(PROJECT_NAME, ayon_id)
+
+    # frame start and end should be updated
+    assert folder["attrib"]["frameStart"] == 10
+    assert folder["attrib"]["frameEnd"] == 210
+
+    update = {
+        "id": kitsu_id,
+        "type": "Shot",
+        "name": "SH001",
+        "nb_frames": 100,
+        "data": {},  # no frame_in
+    }
+    res = api.post(
+        f"{kitsu_url}/push",
+        project_name=PROJECT_NAME,
+        entities=[update],
+    )
+    assert res.status_code == 200
+    folder = api.get_folder_by_id(PROJECT_NAME, ayon_id)
+
+    # frame start and end should be updated
+    assert folder["attrib"]["frameStart"] == 10
+    assert folder["attrib"]["frameEnd"] == 110
+
+
 def test_update_folder_name(api, kitsu_url):
     # do a partial update
     kitsu_id = "shot-id-1"

--- a/tests/tests/test_push_update.py
+++ b/tests/tests/test_push_update.py
@@ -128,8 +128,8 @@ def test_update_task_no_changes(api, kitsu_url):
     )
     assert res.status_code == 200
 
-    # there should be no folders returned as none were created or updated
-    assert res.data == {"folders": {}, "tasks": {}}
+    # there should be no tasks returned as none were created or updated
+    assert res.data["tasks"] == {}
 
 
 def test_update_task_with_new_status(api, kitsu_url):


### PR DESCRIPTION
fixed in for test_push_update so that all are passing. Tests lead to a bug fix in the calculation of end frames covered by:
- test_push_update.py::test_update_folder_attrib
- test_push_update.py::test_calculate_frames

![image](https://github.com/ynput/ayon-kitsu/assets/1951220/c41cd65b-64e3-491f-9e45-14d1c69527f8)
