### PR TITLE
Modifying anatomy attributes instead of replasing it

### DIFF
--- a/server/kitsu/anatomy.py
+++ b/server/kitsu/anatomy.py
@@ -210,8 +210,11 @@ async def get_kitsu_project_anatomy(
 
     anatomy_preset = await get_primary_anatomy_preset()
     anatomy_dict = anatomy_preset.dict()
-
-    anatomy_dict["attributes"] = attributes
+    for key in anatomy_dict["attributes"]:
+        if key in attributes:
+            anatomy_dict["attributes"][key]=attributes[key]
+            
+    #anatomy_dict["attributes"] = attributes
     anatomy_dict["statuses"] = statuses
     anatomy_dict["task_types"] = task_types
 


### PR DESCRIPTION
not replacing whole attributes but replacing matching keys to make applications present after pairing a project

## Changelog Description
<!-- Paragraphs contain detailed information on the changes made to the product or service, providing an in-depth description of the updates and enhancements. They can be used to explain the reasoning behind the changes, or to highlight the importance of the new features. Paragraphs can often include links to further information or support documentation. -->


## Additional info
Issue was reported in this community post [Applications from project anatomy disappear after pairing kitsu project](https://community.ynput.io/t/applications-from-project-anatomy-disappear-after-pairing-kitsu-project/1596)


## Testing notes:

1. create project in kistu
2. pair it to ayon
3. see apps not comming from primamy anatomy presset
