### PR TITLE
Ruff format and README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,29 @@
+# Kitsu addon
+
+CGWire's [Kitsu](https://www.cg-wire.com/kitsu) integration for AYON.
+
+## Developer setup
+
+### Linting and formatting
+
+```shell
+# Install the dev dependencies with Poetry
+$ poetry install --no-root
+
+# Format all the .py files
+$ poetry run ruff format
+```
+
+## Create the package
+
+In order to upload your addon to your AYON server, you need to create the .zip file:
+
+```shell
+$ python create_package.py
+```
+
+It will create it like: `./package/kits-<version>.zip`
+
+## Run tests
+
+See the [tests](./tests/) folder.

--- a/client/ayon_kitsu/__init__.py
+++ b/client/ayon_kitsu/__init__.py
@@ -1,4 +1,4 @@
-""" Addon class definition and Settings definition must be imported here.
+"""Addon class definition and Settings definition must be imported here.
 
 If addon class or settings definition won't be here their definition won't
 be found by OpenPype discovery.

--- a/client/ayon_kitsu/plugins/publish/collect_kitsu_family.py
+++ b/client/ayon_kitsu/plugins/publish/collect_kitsu_family.py
@@ -5,6 +5,7 @@ Requires:
 Provides:
     instance     -> families ([])
 """
+
 import pyblish.api
 
 from ayon_core.lib import filter_profiles
@@ -42,12 +43,10 @@ class CollectKitsuFamily(plugin.KitsuPublishInstancePlugin):
         filtering_criteria = {
             "host_names": host_name,
             "product_types": product_type,
-            "task_names": task_name
+            "task_names": task_name,
         }
         profile = filter_profiles(
-            self.profiles,
-            filtering_criteria,
-            logger=self.log
+            self.profiles, filtering_criteria, logger=self.log
         )
 
         add_kitsu_family = False
@@ -60,11 +59,11 @@ class CollectKitsuFamily(plugin.KitsuPublishInstancePlugin):
                 families_set = set(families) | {product_type}
                 self.log.info(
                     "'{}' families used for additional filtering".format(
-                        families_set))
+                        families_set
+                    )
+                )
                 add_kitsu_family = self._get_add_kitsu_f_from_addit_filters(
-                    additional_filters,
-                    families_set,
-                    add_kitsu_family
+                    additional_filters, families_set, add_kitsu_family
                 )
 
         result_str = "Not adding"
@@ -73,9 +72,11 @@ class CollectKitsuFamily(plugin.KitsuPublishInstancePlugin):
             if "kitsu" not in families:
                 families.append("kitsu")
 
-        self.log.debug("{} 'kitsu' family for instance with '{}'".format(
-            result_str, product_type
-        ))
+        self.log.debug(
+            "{} 'kitsu' family for instance with '{}'".format(
+                result_str, product_type
+            )
+        )
 
     def _get_add_kitsu_f_from_addit_filters(
         self, additional_filters, families, add_kitsu_family

--- a/client/ayon_kitsu/plugins/publish/integrate_kitsu_note.py
+++ b/client/ayon_kitsu/plugins/publish/integrate_kitsu_note.py
@@ -82,9 +82,9 @@ class IntegrateKitsuNote(KitsuPublishContextPlugin):
 
             # Check if any status condition is not met
             allow_status_change = True
-            for status_cond in (
-                self.status_change_conditions["status_conditions"]
-            ):
+            for status_cond in self.status_change_conditions[
+                "status_conditions"
+            ]:
                 condition = status_cond["condition"] == "equal"
                 match = status_cond["short_name"].upper() == shortname
                 if match and not condition or condition and not match:

--- a/client/ayon_kitsu/version.py
+++ b/client/ayon_kitsu/version.py
@@ -1,3 +1,4 @@
 # -*- coding: utf-8 -*-
 """Package declaring kitsu addon version."""
+
 __version__ = "1.2.4-dev.1"

--- a/create_package.py
+++ b/create_package.py
@@ -305,9 +305,7 @@ def zip_client_side(addon_package_dir: str, log: logging.Logger):
 
 
 def create_server_package(
-    output_dir: str,
-    addon_output_dir: str,
-    log: logging.Logger
+    output_dir: str, addon_output_dir: str, log: logging.Logger
 ):
     """Create server package zip file.
 
@@ -320,14 +318,10 @@ def create_server_package(
     """
 
     log.info("Creating server package")
-    output_path = os.path.join(
-        output_dir, f"{ADDON_NAME}-{ADDON_VERSION}.zip"
-    )
+    output_path = os.path.join(output_dir, f"{ADDON_NAME}-{ADDON_VERSION}.zip")
     with ZipFileLongPaths(output_path, "w", zipfile.ZIP_DEFLATED) as zipf:
         # Write a manifest to zip
-        zipf.write(
-            os.path.join(CURRENT_DIR, "package.py"), "package.py"
-        )
+        zipf.write(os.path.join(CURRENT_DIR, "package.py"), "package.py")
 
         # Move addon content to zip into 'addon' directory
         addon_output_dir_offset = len(addon_output_dir) + 1
@@ -486,7 +480,7 @@ if __name__ == "__main__":
         "--debug",
         dest="debug",
         action="store_true",
-        help="Debug log messages."
+        help="Debug log messages.",
     )
     parser.add_argument(
         "--upload",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,11 +12,5 @@ authors = ["Ynput Team <team@ynput.io>"]
 [tool.poetry.dependencies]
 python = "^3.9"
 
-[tool.poetry.dev-dependencies]
-gazu = "^0.9.3"
-ayon-python-api = "^1.0.1"
-pyblish = "^1.7.0"
-qtpy = "^2.4.1"
-pydantic = "^2.6.4"
-nxtools = "^1.6"
-python-dotenv = "^1.0.1"
+[tool.poetry.group.dev.dependencies]
+ruff = "^0.6.9"

--- a/server/__init__.py
+++ b/server/__init__.py
@@ -59,9 +59,7 @@ class KitsuAddon(BaseServerAddon):
     #
 
     async def sync(
-        self,
-        user: CurrentUser,
-        project_name: str
+        self, user: CurrentUser, project_name: str
     ) -> EmptyResponse:
         await sync_request(project_name, user)
 

--- a/server/kitsu/__init__.py
+++ b/server/kitsu/__init__.py
@@ -1,4 +1,4 @@
-__all__ = ['Kitsu', 'KitsuMock']
+__all__ = ["Kitsu", "KitsuMock"]
 
 from .kitsu import Kitsu
 from .kitsu_mock import KitsuMock

--- a/server/kitsu/addon_helpers.py
+++ b/server/kitsu/addon_helpers.py
@@ -7,10 +7,9 @@ A collection of helper functions for Ayon Addons
 minimal dependencies, pytest unit tests
 """
 
+
 def required_values(
-    entity: dict[str, Any],
-    keys: list[str],
-    allow_empty_value: bool = False
+    entity: dict[str, Any], keys: list[str], allow_empty_value: bool = False
 ) -> list[Any]:
     """check the entity dict has the required keys and a value for each"""
     values = []

--- a/server/kitsu/anatomy.py
+++ b/server/kitsu/anatomy.py
@@ -216,9 +216,9 @@ async def get_kitsu_project_anatomy(
     anatomy_dict = anatomy_preset.dict()
     for key in anatomy_dict["attributes"]:
         if key in attributes:
-            anatomy_dict["attributes"][key]=attributes[key]
+            anatomy_dict["attributes"][key] = attributes[key]
 
-    #anatomy_dict["attributes"] = attributes
+    # anatomy_dict["attributes"] = attributes
     anatomy_dict["statuses"] = statuses
     anatomy_dict["task_types"] = task_types
 

--- a/server/kitsu/push.py
+++ b/server/kitsu/push.py
@@ -25,7 +25,6 @@ from .utils import (
     get_task_by_kitsu_id,
     get_user_by_kitsu_id,
     update_project,
-
     update_folder,
     update_task,
 )
@@ -232,11 +231,8 @@ async def sync_person(
     existing_users: dict[str, Any],
     entity_dict: "EntityDict",
 ):
-
-    first_name, entity_id= required_values(
-        entity_dict, ["first_name", "id"]
-    )
-    last_name = entity_dict.get("last_name", '')
+    first_name, entity_id = required_values(entity_dict, ["first_name", "id"])
+    last_name = entity_dict.get("last_name", "")
 
     # == check should Person entity be synced ==
     # do not sync Kitsu API bots
@@ -417,8 +413,7 @@ async def sync_folder(
             return
         # ensure folder type exists
         if entity_dict["type"] not in [
-            f["name"]
-            for f in project.folder_types
+            f["name"] for f in project.folder_types
         ]:
             logging.warning(
                 f"Folder type {entity_dict['type']} does not exist. Creating."
@@ -469,8 +464,7 @@ async def ensure_task_type(
 ) -> bool:
     """#TODO: kitsu listener for new task types would be preferable"""
     if task_type_name not in [
-        task_type["name"]
-        for task_type in project.task_types
+        task_type["name"] for task_type in project.task_types
     ]:
         logging.info(
             f"Creating task type {task_type_name} for '{project.name}'"
@@ -492,10 +486,7 @@ async def ensure_task_status(
 ) -> bool:
     """#TODO: kitsu listener for new task statuses would be preferable"""
 
-    if task_status_name not in [
-        status["name"]
-        for status in project.statuses
-    ]:
+    if task_status_name not in [status["name"] for status in project.statuses]:
         logging.info(
             f"Creating task status {task_status_name} for '{project.name}'"
         )
@@ -612,9 +603,7 @@ async def push_entities(
             continue
 
         if entity_dict["type"] == "Project":
-            await sync_project(
-                addon, user, project, entity_dict, payload.mock
-            )
+            await sync_project(addon, user, project, entity_dict, payload.mock)
         elif entity_dict["type"] == "Person":
             if settings.sync_settings.sync_users.enabled:
                 await create_access_group(

--- a/server/kitsu/utils.py
+++ b/server/kitsu/utils.py
@@ -24,9 +24,8 @@ def calculate_end_frame(
         return entity_dict["data"].get("frame_out")
 
     # Calculate the end-frame
-    if (
-        entity_dict.get("nb_frames")
-        and not entity_dict["data"].get("frame_out")
+    if entity_dict.get("nb_frames") and not entity_dict["data"].get(
+        "frame_out"
     ):
         frame_start = entity_dict["data"].get("frame_in")
         # If kitsu doesn't have a frame in, get it from the folder in Ayon

--- a/server/settings/publish_plugins.py
+++ b/server/settings/publish_plugins.py
@@ -4,13 +4,9 @@ from ayon_server.settings import BaseSettingsModel, SettingsField
 class CollectFamilyAdvancedFilterModel(BaseSettingsModel):
     _layout = "expanded"
     families: list[str] = SettingsField(
-        default_factory=list,
-        title="Additional Families"
+        default_factory=list, title="Additional Families"
     )
-    add_kitsu_family: bool = SettingsField(
-        True,
-        title="Add Kitsu Family"
-    )
+    add_kitsu_family: bool = SettingsField(True, title="Add Kitsu Family")
 
 
 class CollectFamilyProfile(BaseSettingsModel):
@@ -75,8 +71,8 @@ class StatusChangeConditionsModel(BaseSettingsModel):
     status_conditions: list[StatusChangeCondition] = SettingsField(
         default_factory=list, title="Status conditions"
     )
-    family_requirements: list[StatusChangeFamilyRequirementModel] = SettingsField(
-        default_factory=list, title="Family requirements"
+    family_requirements: list[StatusChangeFamilyRequirementModel] = (
+        SettingsField(default_factory=list, title="Family requirements")
     )
 
 
@@ -97,7 +93,7 @@ class IntegrateKitsuNotes(BaseSettingsModel):
     note_status_shortname: str = SettingsField(title="Note shortname")
     status_change_conditions: StatusChangeConditionsModel = SettingsField(
         default_factory=StatusChangeConditionsModel,
-        title="Status change conditions"
+        title="Status change conditions",
     )
     custom_comment_template: CustomCommentTemplateModel = SettingsField(
         default_factory=CustomCommentTemplateModel,
@@ -108,11 +104,10 @@ class IntegrateKitsuNotes(BaseSettingsModel):
 class PublishPlugins(BaseSettingsModel):
     CollectKitsuFamily: CollectKitsuFamilyPluginModel = SettingsField(
         default_factory=CollectKitsuFamilyPluginModel,
-        title="Collect Kitsu Family"
+        title="Collect Kitsu Family",
     )
     IntegrateKitsuNote: IntegrateKitsuNotes = SettingsField(
-        default_factory=IntegrateKitsuNotes,
-        title="Integrate Kitsu Note"
+        default_factory=IntegrateKitsuNotes, title="Integrate Kitsu Note"
     )
 
 
@@ -121,161 +116,105 @@ PUBLISH_DEFAULT_VALUES = {
         "enabled": True,
         "profiles": [
             {
-                "host_names": [
-                    "traypublisher"
-                ],
+                "host_names": ["traypublisher"],
                 "product_types": [],
                 "task_types": [],
                 "task_names": [],
                 "add_ftrack_family": True,
-                "advanced_filtering": []
+                "advanced_filtering": [],
             },
             {
-                "host_names": [
-                    "traypublisher"
-                ],
-                "product_types": [
-                    "matchmove",
-                    "shot"
-                ],
+                "host_names": ["traypublisher"],
+                "product_types": ["matchmove", "shot"],
                 "task_types": [],
                 "task_names": [],
                 "add_kitsu_family": False,
-                "advanced_filtering": []
+                "advanced_filtering": [],
             },
             {
-                "host_names": [
-                    "traypublisher"
-                ],
-                "product_types": [
-                    "plate",
-                    "review",
-                    "audio"
-                ],
+                "host_names": ["traypublisher"],
+                "product_types": ["plate", "review", "audio"],
                 "task_types": [],
                 "task_names": [],
                 "add_kitsu_family": False,
                 "advanced_filtering": [
-                    {
-                        "families": [
-                            "clip",
-                            "review"
-                        ],
-                        "add_kitsu_family": True
-                    }
-                ]
+                    {"families": ["clip", "review"], "add_kitsu_family": True}
+                ],
             },
             {
-                "host_names": [
-                    "maya"
-                ],
+                "host_names": ["maya"],
                 "product_types": [
                     "model",
                     "setdress",
                     "animation",
                     "look",
                     "rig",
-                    "camera"
+                    "camera",
                 ],
                 "task_types": [],
                 "task_names": [],
                 "add_kitsu_family": True,
-                "advanced_filtering": []
+                "advanced_filtering": [],
             },
             {
-                "host_names": [
-                    "tvpaint"
-                ],
-                "product_types": [
-                    "renderPass"
-                ],
+                "host_names": ["tvpaint"],
+                "product_types": ["renderPass"],
                 "task_types": [],
                 "task_names": [],
                 "add_kitsu_family": False,
-                "advanced_filtering": []
+                "advanced_filtering": [],
             },
             {
-                "host_names": [
-                    "tvpaint"
-                ],
+                "host_names": ["tvpaint"],
                 "product_types": [],
                 "task_types": [],
                 "task_names": [],
                 "add_kitsu_family": True,
-                "advanced_filtering": []
+                "advanced_filtering": [],
             },
             {
-                "host_names": [
-                    "nuke"
-                ],
-                "product_types": [
-                    "write",
-                    "render",
-                    "prerender"
-                ],
+                "host_names": ["nuke"],
+                "product_types": ["write", "render", "prerender"],
                 "task_types": [],
                 "task_names": [],
                 "add_kitsu_family": False,
                 "advanced_filtering": [
-                    {
-                        "families": [
-                            "review"
-                        ],
-                        "add_kitsu_family": True
-                    }
-                ]
+                    {"families": ["review"], "add_kitsu_family": True}
+                ],
             },
             {
-                "host_names": [
-                    "aftereffects"
-                ],
-                "product_types": [
-                    "render",
-                    "workfile"
-                ],
+                "host_names": ["aftereffects"],
+                "product_types": ["render", "workfile"],
                 "task_types": [],
                 "task_names": [],
                 "add_kitsu_family": True,
-                "advanced_filtering": []
+                "advanced_filtering": [],
             },
             {
-                "host_names": [
-                    "flame"
-                ],
-                "product_types": [
-                    "plate",
-                    "take"
-                ],
+                "host_names": ["flame"],
+                "product_types": ["plate", "take"],
                 "task_types": [],
                 "task_names": [],
                 "add_kitsu_family": True,
-                "advanced_filtering": []
+                "advanced_filtering": [],
             },
             {
-                "host_names": [
-                    "houdini"
-                ],
-                "product_types": [
-                    "usd"
-                ],
+                "host_names": ["houdini"],
+                "product_types": ["usd"],
                 "task_types": [],
                 "task_names": [],
                 "add_kitsu_family": True,
-                "advanced_filtering": []
+                "advanced_filtering": [],
             },
             {
-                "host_names": [
-                    "photoshop"
-                ],
-                "product_types": [
-                    "review"
-                ],
+                "host_names": ["photoshop"],
+                "product_types": ["review"],
                 "task_types": [],
                 "task_names": [],
                 "add_kitsu_family": True,
-                "advanced_filtering": []
-            }
-        ]
+                "advanced_filtering": [],
+            },
+        ],
     },
     "IntegrateKitsuNote": {
         "set_status_note": False,
@@ -294,5 +233,5 @@ PUBLISH_DEFAULT_VALUES = {
 | family | `{family}` |
 | name | `{name}` |""",
         },
-    }
+    },
 }

--- a/services/processor/processor/fullsync.py
+++ b/services/processor/processor/fullsync.py
@@ -29,15 +29,15 @@ def get_assets(
 def get_tasks(
     kitsu_project_id: str,
     task_types: dict[str, str],
-    task_statuses: dict[str, str]
+    task_statuses: dict[str, str],
 ) -> list[dict[str, str]]:
     tasks: list[dict[str, str]] = []
     for record in gazu.task.all_tasks_for_project(kitsu_project_id):
         record["persons"]: list[dict[str, str]] = []
         for id in record["assignees"]:
-            record["persons"].append({
-                "email": gazu.person.get_person(id)["email"]
-            })
+            record["persons"].append(
+                {"email": gazu.person.get_person(id)["email"]}
+            )
         tasks.append(
             preprocess_task(
                 kitsu_project_id, record, task_types, task_statuses

--- a/services/processor/processor/processor.py
+++ b/services/processor/processor/processor.py
@@ -96,12 +96,12 @@ class KitsuProcessor:
                 )
 
             try:
-                self.kitsu_login_email = (
-                    ayon_api.get_secret(email_secret)["value"]
-                )
-                self.kitsu_login_password = (
-                    ayon_api.get_secret(password_secret)["value"]
-                )
+                self.kitsu_login_email = ayon_api.get_secret(email_secret)[
+                    "value"
+                ]
+                self.kitsu_login_password = ayon_api.get_secret(
+                    password_secret
+                )["value"]
             except KeyError as e:
                 raise KitsuSettingsError(f"Secret `{e}` not found") from e
 
@@ -302,7 +302,7 @@ class KitsuProcessor:
         self.pairing_list.append(
             {
                 "kitsuProjectId": kitsu_project_id,
-                "ayonProjectName": ayon_project_name
+                "ayonProjectName": ayon_project_name,
             }
         )
 

--- a/services/processor/processor/utils.py
+++ b/services/processor/processor/utils.py
@@ -1,4 +1,4 @@
-""" utils shared between fullsync.py and update_from_kitsu.py """
+"""utils shared between fullsync.py and update_from_kitsu.py"""
 
 import ayon_api
 import gazu


### PR DESCRIPTION
## Changelog Description

This is a follow-up of https://github.com/ynput/ayon-kitsu/pull/79 by @iLLiCiTiT 

This PR adds the following:

- Removed the top `pyproject.toml` dependencies that were already present in the `tests` folder and added Ruff as the only dev dependencies (so devs don't have to install Ruff globally on their machine and can install it with Poetry in the project's venv)
- Applied `ruff format` on all the `client` Python source files using the Ruff config
- Added the repo's `README.md` file (which you can see [here](https://github.com/johhnry/ayon-kitsu/tree/ruff-format-readme)) with instructions on how to install the dev dependencies and format using Ruff + the basic structure found on other repos.
