### PR TITLE
Fix Kitsu Task type and status sync + tests

### DIFF
--- a/server/kitsu/push.py
+++ b/server/kitsu/push.py
@@ -478,7 +478,8 @@ async def ensure_task_type(
         project.task_types.append(
             {
                 "name": task_type_name,
-                "short_name": task_type_name[:4],
+                "shortName": task_type_name[:4],
+                "icon": "task_alt",
             }
         )
         await project.save()
@@ -502,7 +503,8 @@ async def ensure_task_status(
         project.statuses.append(
             {
                 "name": task_status_name,
-                "short_name": task_status_name[:4],
+                "icon": "task_alt",
+                "shortName": task_status_name[:4],
             }
         )
         await project.save()

--- a/tests/pyproject.toml
+++ b/tests/pyproject.toml
@@ -2,20 +2,22 @@
 name = "ayon-kitsu"
 version = "1.2.4-dev.1"
 description = ""
+package-mode = false
 authors = ["Martastain <martas@imm.cz>", "Scott McDonnell <scott@jammedia.com", "Jacob Danell <jacob@emberlight.se>"]
 
 [tool.poetry.dependencies]
 python = "^3.8"
 
-[tool.poetry.dev-dependencies]
+[tool.poetry.group.dev.dependencies]
 pytest = "^7.0.1"
 gazu = "^0.9.17"
 ayon-python-api = "^1.0.0"
 requests = "^2.27.1"
 nxtools = "^1.6"
-codenamize = "^1.2.4-dev.1"
 pytest-mock = "^3.12.0"
 python-dotenv = "^1.0.1"
+codenamize = "^1.2.3"
+httpx = "^0.27.2"
 
 [build-system]
 requires = ["poetry-core>=1.0.0"]

--- a/tests/tests/test_push_create.py
+++ b/tests/tests/test_push_create.py
@@ -292,6 +292,7 @@ def test_push_tasks(api, kitsu_url, monkeypatch):
         "clipOut": 1,
         "clipIn": 1,
         "pixelAspect": 1.0,
+        "priority": "normal",
     }
 
     res = api.get(f"/projects/{PROJECT_NAME}/tasks/{tasks['task-id-2']}")
@@ -314,6 +315,7 @@ def test_push_tasks(api, kitsu_url, monkeypatch):
         "clipOut": 1,
         "clipIn": 1,
         "pixelAspect": 1.0,
+        "priority": "normal",
     }
 
     # ---------------------------------------------

--- a/tests/tests/test_push_project.py
+++ b/tests/tests/test_push_project.py
@@ -106,7 +106,19 @@ def test_update_project_statuses(api, kitsu_url, ensure_kitsu_server_setting):
     res = api.put(f"/projects/{project_name}", **project_meta)
 
     project = api.get_project(project_name)
-    assert project["statuses"] == [{"name": "Todo"}]
+    assert project["statuses"] == [
+        {
+            "name": "Todo",
+            "scope": [
+                "folder",
+                "task",
+                "product",
+                "version",
+                "representation",
+                "workfile",
+            ],
+        }
+    ]
 
     res = api.post(
         f"{kitsu_url}/push",
@@ -124,6 +136,14 @@ def test_update_project_statuses(api, kitsu_url, ensure_kitsu_server_setting):
             "name": "Todo",
             "shortName": "TODO",
             "state": "in_progress",
+            "scope": [
+                "folder",
+                "product",
+                "version",
+                "representation",
+                "task",
+                "workfile",
+            ],
         },
         {
             "color": "#22D160",
@@ -131,6 +151,14 @@ def test_update_project_statuses(api, kitsu_url, ensure_kitsu_server_setting):
             "name": "Approved",
             "shortName": "App",
             "state": "in_progress",
+            "scope": [
+                "folder",
+                "product",
+                "version",
+                "representation",
+                "task",
+                "workfile",
+            ],
         },
     ]
     api.delete(f"/projects/{project_name}")


### PR DESCRIPTION
## Changelog Description
This PR mainly solves #72 

- Fixed the `short_name` key to `shortName`
- Added the default icon `task_alt` for both task type and status
- Re ran unit tests and fixed database changes (new `scope` field in status, `priority` field on tasks)
- Use Poetry's new [dependency groups](https://python-poetry.org/docs/managing-dependencies/) for unit tests
- Use [`package-mode = false`](https://python-poetry.org/docs/pyproject#package-mode) for unit tests because we don't need to treat the code as a package
- Fix `codenamize` dependency which was version `^1.2.4-dev.1` and [didn't exist on Pip](https://pypi.org/project/codenamize/#history)
- Add missing `httpx` dependency


## Testing notes:

1. Create a new task type in Kitsu
2. Add it to your project
3. Create that task on an asset/shot
4. Make sure that you can browse the folders in the Launcher without errors and that it has the proper `icon` and `shortName` fields
5. You can do the same with task statuses
