### PR TITLE
Fix: subtract 1 in end frame calculation

### DIFF
--- a/server/kitsu/utils.py
+++ b/server/kitsu/utils.py
@@ -33,7 +33,7 @@ def calculate_end_frame(
         if frame_start is None and hasattr(folder.attrib, "frameStart"):
             frame_start = folder.attrib.frameStart
         if frame_start is not None:
-            return int(frame_start) + int(entity_dict["nb_frames"])
+            return int(frame_start) + int(entity_dict["nb_frames"]) - 1
 
 
 def create_name_and_label(kitsu_name: str) -> dict[str, str]:

--- a/services/processor/processor/processor.py
+++ b/services/processor/processor/processor.py
@@ -315,8 +315,14 @@ class KitsuProcessor:
             if startup:
                 logging.info("Running sync for all paired projects")
                 for pair in self.pairing_list:
-                    if pair.get("kitsuProjectId") and pair.get("ayonProjectName"):
-                        project_full_sync(self, pair["kitsuProjectId"], pair["ayonProjectName"])
+                    project_id = pair.get("kitsuProjectId")
+                    project_name = pair.get("ayonProjectName")
+                    if project_id and project_name:
+                        project_full_sync(
+                            self,
+                            project_id,
+                            project_name,
+                        )
                 startup = False
 
             # Check for a new sync job


### PR DESCRIPTION
## Changelog Description

This PR fixes #85 


## Additional info

The feature was fixed [here](https://github.com/ynput/ayon-kitsu/pull/45) but removed [here](https://github.com/ynput/ayon-kitsu/pull/59).

## Testing notes:

1. Change in/nb_frames in Kitsu for a shot
2. Check that the values for start/end frames are correct in AYON
