### PR TITLE
Feature: Sync paired projects at processor startup

### DIFF
--- a/services/processor/processor/fullsync.py
+++ b/services/processor/processor/fullsync.py
@@ -46,9 +46,16 @@ def get_tasks(
     return tasks
 
 
-def full_sync(
+def project_full_sync(
     parent: "KitsuProcessor", kitsu_project_id: str, project_name: str
 ):
+    """Sync all entities from a Kitsu project to an Ayon project.
+
+    Args:
+        parent (KitsuProcessor): The parent processor
+        kitsu_project_id (str): The Kitsu project id
+        project_name (str): The Ayon
+    """
     start_time = time.time()
     logging.info(f"Syncing kitsu project {kitsu_project_id} to {project_name}")
 


### PR DESCRIPTION
## Changelog Description
Paired projects are automatically synchronized when a Kitsu processor is started.

Fix #90 

## Additional review information
Also renamed `full_sync` to `project_full_sync` to make it more explicit, and added some docstring.

## Testing notes:
1. Pair a project
2. Stop your Kitsu processor
3. Make a change on Kitsu side
4. Start the modified processor
5. Change is applied without having to click on `Sync now` manually
