### PR TITLE
Fill environment variables for farm jobs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,6 @@ frontend/.pnp.cjs
 frontend/.pnp.loader.mjs
 
 dist/
+
+# JetBrains
+.idea/

--- a/client/ayon_kitsu/plugins/publish/collect_farm_env_variables.py
+++ b/client/ayon_kitsu/plugins/publish/collect_farm_env_variables.py
@@ -1,0 +1,28 @@
+import os
+
+import pyblish.api
+
+try:
+    from ayon_core.pipeline.publish import FARM_JOB_ENV_DATA_KEY
+except ImportError:
+    # NOTE Can be removed when ayon-core >= 1.0.10 is required in package.py
+    FARM_JOB_ENV_DATA_KEY = "farmJobEnv"
+
+
+class CollectKitsuJobEnvVars(pyblish.api.ContextPlugin):
+    """Collect set of environment variables to submit with deadline jobs"""
+    order = pyblish.api.CollectorOrder - 0.45
+    label = "Collect Kitsu farm environment variables"
+    targets = ["local"]
+
+    def process(self, context):
+        env = context.data.setdefault(FARM_JOB_ENV_DATA_KEY, {})
+        for key in [
+            "KITSU_SERVER",
+            "KITSU_LOGIN",
+            "KITSU_PWD",
+        ]:
+            value = os.getenv(key)
+            if value:
+                self.log.debug(f"Setting job env: {key}: {value}")
+                env[key] = value


### PR DESCRIPTION
## Changelog Description
Fill environment variables for farm in publish plugins.

## Additional review information
Move control to collect kitsu environment variables, needed for farm jobs, to kitsu addon.

## Testing notes:
1. At this moment probably nothing changed because deadline has to stop auto-fill the keys.

Resolves https://github.com/ynput/ayon-kitsu/issues/91