### PR TITLE
fix: set poetry to only install package dependencies to avoid build error.

### DIFF
--- a/services/processor/pyproject.toml
+++ b/services/processor/pyproject.toml
@@ -3,6 +3,7 @@ name = "kitsu-processor"
 version = "1.2.4-dev.1"
 description = "Kitsu Integration for Ayon"
 authors = ["Martin Wacker <martin@ynput.io>"]
+package-mode = false
 
 [tool.poetry.dependencies]
 python = "^3.11"


### PR DESCRIPTION
## Changelog Description

The new major version Poetry 2.0.0 was released a few days ago, and amongst the changes is to change the warning raised when trying to install a package where the package folder isn't found from warning to a hard error: see https://github.com/python-poetry/poetry/pull/9333

As the `package-mode = false` configuration option isn't set in this repository and no packages have been defined, it looks for a `./services/processor/kitsu-processor/` package folder that obviously doesn't exist. This would have likely been showing up as a warning before but was never noticed as it wasn't an error until now, and the build would still finish successfully. 

With the move to Poetry 2.0.0, it now errors with
```
Installing the current project: kitsu-processor (1.3.6)
...
Warning: The current project could not be installed: No file/folder found for package kitsu-processor
If you do not want to install the current project use --no-root.
If you want to use Poetry only for dependency management but not for packaging, you can disable package mode by setting package-mode = false in your pyproject.toml file.
If you did intend to install the current project, you may need to set `packages` in your pyproject.toml file.
```

The three ways to get around it that come to mind are to:
1. Set the `package-mode = false` option to let Poetry know that it's only needed to install dependencies (what it's doing already). The processor module imports are all relatively referenced so this currently works.
2. Revert back to using Poetry 1.x for the build process until there's been more time to test and plan the migration to `2.x`
3. Configure the processor to be a proper Poetry package.

This PR implements option 1 as it's the simplest way to get builds of the processor back up and running, but if you want to go in a different direction @martastain let me know and I can close this PR and convert it to an issue - for now this is how we're addressing the issue in our local fork to get builds back so I figured I'd raise a PR for it, but happy to follow along with whatever you suggest.

## Testing notes:
1. Clone down the repository and try to build the processor image.
2. Set `package-mode = false` in the pyproject config and rebuild.
3. Happy builds!
