### PR TITLE
Enhancement: Log skipped representation

### DIFF
--- a/client/ayon_kitsu/plugins/publish/integrate_kitsu_review.py
+++ b/client/ayon_kitsu/plugins/publish/integrate_kitsu_review.py
@@ -32,6 +32,10 @@ class IntegrateKitsuReview(KitsuPublishInstancePlugin):
         for representation in instance.data.get("representations", []):
             # Skip if not tagged as review
             if "kitsureview" not in representation.get("tags", []):
+                self.log.debug(
+                    f"Skipping representation {representation['name']} "
+                    "because it has no 'kitsureview' tag"
+                )
                 continue
             review_path = representation.get("published_path")
             self.log.debug(f"Found review at: {review_path}")


### PR DESCRIPTION
## Changelog Description
Ensuring anytime a representation is skipped because it doesn't have the `kitsureview` tag, it's visible in the logs. I'm currently dealing with an issue related to this exact case in photoshop, and it would have been much easier to diagnose if this was logged right from the start. So I think it could be helpful to change that, in case such issue appears again in the future.

## Additional review information
It's a simple debug log.

## Testing notes:
- Ensure you have kitsu addon installed, but some representations don't have the `kitsureview` tag.
- Publish.
- Open the Details panel and check the logs for the Kitsu Review plugin.
- Your skipped representations should be mentioned in the logs.