### PR TITLE
fix(pairing): resolve KeyError: 0 in sync_request by using dict key access

### DIFF
--- a/server/kitsu/init_pairing.py
+++ b/server/kitsu/init_pairing.py
@@ -51,10 +51,10 @@ async def sync_request(
 ):
     if kitsu_project_id is None:
         async for res in Postgres.iterate(
-            "SELECT data->>'kitsuProjectId' FROM projects WHERE name = $1",
+            "SELECT data->>'kitsuProjectId' as kitsu_project_id FROM projects WHERE name = $1",
             project_name,
         ):
-            kitsu_project_id = res[0]
+            kitsu_project_id = res["kitsu_project_id"]
 
     hash = hashlib.sha256(
         f"kitsu_sync_{project_name}_{kitsu_project_id}".encode("utf-8")

--- a/server/kitsu/init_pairing.py
+++ b/server/kitsu/init_pairing.py
@@ -51,7 +51,8 @@ async def sync_request(
 ):
     if kitsu_project_id is None:
         async for res in Postgres.iterate(
-            "SELECT data->>'kitsuProjectId' as kitsu_project_id FROM projects WHERE name = $1",
+            "SELECT data->>'kitsuProjectId' as kitsu_project_id "
+            "FROM projects WHERE name = $1",
             project_name,
         ):
             kitsu_project_id = res["kitsu_project_id"]


### PR DESCRIPTION
## Description
Fixes #120
This PR fixes a `KeyError: 0` that occurs during [sync_request](cci:1://file:///g:/Projects/Dev/AYON/docker/ayon-docker-main/addons/kitsu/dev/fork/ayon-kitsu/server/kitsu/init_pairing.py:46:0-98:9) (specifically in [init_pairing.py](cci:7://file:///g:/Projects/Dev/AYON/docker/ayon-docker-main/addons/kitsu/dev/fork/ayon-kitsu/server/kitsu/init_pairing.py:0:0-0:0)) when running against recent versions of AYON Server.

## Context
In newer AYON Server environments, the `Postgres.iterate` method may yield pure Python `dict` objects instead of `asyncpg.Record` objects.
*   **Old Behavior:** Returned a tuple-like object, allowing `res[0]`.
*   **New Behavior:** Returns a `dict`, causing `res[0]` to raise `KeyError: 0`.
* 
## Changes
*   Updated the SQL query to explicitly alias the column: `SELECT ... AS kitsu_project_id`.
*   Changed the result retrieval to use dictionary key access: `res["kitsu_project_id"]`.
This approach is robust as it correctly handles both `asyncpg.Record` (which supports dict keys) and standard dictionary return types.

## Testing
1. Triggered a Kitsu pairing/sync.
2. Verified that the `KeyError: 0` no longer occurs and the project ID is correctly retrieved.