### PR TITLE
Feature: Sync casting breakdown

### DIFF
--- a/server/kitsu/push.py
+++ b/server/kitsu/push.py
@@ -632,7 +632,7 @@ async def sync_casting(
     target_kitsu_id = entity_dict.get("target_id")
     target_type = entity_dict.get("target_type", "Shot")
     asset_ids = entity_dict.get("asset_ids", {})
-    
+
     if not target_kitsu_id:
         logging.warning("SyncCasting missing target_id")
         return
@@ -665,7 +665,7 @@ async def sync_casting(
 
     # Build mapping of asset_kitsu_id -> list of existing links
     existing_links_by_asset: dict[str, list[dict]] = {}
-    
+
     for link in existing_links:
         # Try to get asset_kitsu_id from link data
         link_data = link.get("data")
@@ -673,7 +673,7 @@ async def sync_casting(
             asset_kitsu_id = link_data.get("kitsuAssetId")
         else:
             asset_kitsu_id = None
-        
+
         if not asset_kitsu_id:
             # Fallback: try to find asset by input_id by querying the folder
             input_id = link.get("input_id")
@@ -684,7 +684,7 @@ async def sync_casting(
                 except Exception:
                     # Folder not found or no kitsuId, skip this link
                     continue
-        
+
         if asset_kitsu_id:
             if asset_kitsu_id not in existing_links_by_asset:
                 existing_links_by_asset[asset_kitsu_id] = []
@@ -703,7 +703,7 @@ async def sync_casting(
             continue
 
         existing_count = len(existing_links_by_asset.get(asset_kitsu_id, []))
-        
+
         # Delete excess links (more in AYON than in Kitsu)
         if existing_count > desired_count:
             links_to_delete = existing_links_by_asset[asset_kitsu_id][:existing_count - desired_count]
@@ -718,7 +718,7 @@ async def sync_casting(
                     f"Deleted excess casting link {link.get('input_id')}->{target_folder.id} "
                     f"(asset {asset_kitsu_id}, had {existing_count}, need {desired_count})"
                 )
-        
+
         # Create missing links (more in Kitsu than in AYON)
         elif existing_count < desired_count:
             for occurence_num in range(existing_count + 1, desired_count + 1):
@@ -739,7 +739,7 @@ async def sync_casting(
                     f"Created casting link {asset_folder.name}->{target_folder.name} "
                     f"(asset {asset_kitsu_id}, occurence {occurence_num}/{desired_count})"
                 )
-    
+
     # Handle assets that were removed from Kitsu (exist in AYON but not in count dict)
     # Find links for assets not in the count dict
     for link in existing_links:
@@ -749,7 +749,7 @@ async def sync_casting(
             asset_kitsu_id = link_data.get("kitsuAssetId")
         else:
             asset_kitsu_id = None
-        
+
         if not asset_kitsu_id:
             # Fallback: try to find asset by input_id
             input_id = link.get("input_id")
@@ -760,7 +760,7 @@ async def sync_casting(
                 except Exception:
                     # Folder not found, skip
                     continue
-        
+
         # If this asset is not in the asset_ids dict, it was removed from Kitsu
         if asset_kitsu_id and asset_kitsu_id not in asset_ids:
             await delete_entity_link(

--- a/server/kitsu/push.py
+++ b/server/kitsu/push.py
@@ -52,7 +52,6 @@ KitsuEntityType = Literal[
     "Task",
     "Person",
     "Project",
-    "CastingLink",
     "SyncCasting",
 ]
 
@@ -591,62 +590,6 @@ async def sync_task(
             existing_tasks[entity_dict["id"]] = target_task.id
 
 
-async def sync_casting_link(
-    addon: "KitsuAddon",
-    user: "UserEntity",
-    project: "ProjectEntity",
-    entity_dict: "EntityDict",
-    settings,
-):
-    if not settings.sync_settings.sync_casting.enabled:
-        return
-
-    asset_kitsu_id = entity_dict.get("asset_id") or entity_dict.get("assetId")
-    target_kitsu_id = entity_dict.get("target_id") or entity_dict.get("targetId")
-    if not asset_kitsu_id or not target_kitsu_id:
-        logging.warning("CastingLink missing asset_id or target_id")
-        return
-
-    asset_folder = await get_folder_by_kitsu_id(
-        project.name,
-        asset_kitsu_id,
-    )
-    if not asset_folder:
-        logging.warning(
-            f"CastingLink asset not found for kitsuId {asset_kitsu_id}"
-        )
-        return
-
-    target_folder = await get_folder_by_kitsu_id(
-        project.name,
-        target_kitsu_id,
-    )
-    if not target_folder:
-        logging.warning(
-            f"CastingLink target not found for kitsuId {target_kitsu_id}"
-        )
-        return
-
-    link_type = (
-        settings.sync_settings.sync_casting.casting_link_type or "breakdown"
-    )
-    # Ensure link_type has proper format: name|input_type|output_type
-    if "|" not in link_type:
-        link_type = f"{link_type}|folder|folder"
-    await create_entity_link(
-        project_name=project.name,
-        user=user,
-        ayon_server_url=entity_dict["ayon_server_url"],
-        input_id=asset_folder.id,
-        output_id=target_folder.id,
-        link_type=link_type,
-        data={
-            "kitsuAssetId": asset_kitsu_id,
-            "kitsuTargetId": target_kitsu_id,
-        },
-    )
-
-
 async def sync_casting(
     addon: "KitsuAddon",
     user: "UserEntity",
@@ -721,9 +664,7 @@ async def sync_casting(
     )
 
     # Build mapping of asset_kitsu_id -> list of existing links
-    # Also map input_id -> asset_kitsu_id for lookup
     existing_links_by_asset: dict[str, list[dict]] = {}
-    input_id_to_asset_kitsu_id: dict[str, str] = {}
     
     for link in existing_links:
         # Try to get asset_kitsu_id from link data
@@ -748,7 +689,6 @@ async def sync_casting(
             if asset_kitsu_id not in existing_links_by_asset:
                 existing_links_by_asset[asset_kitsu_id] = []
             existing_links_by_asset[asset_kitsu_id].append(link)
-            input_id_to_asset_kitsu_id[link.get("input_id")] = asset_kitsu_id
 
     # Process each asset with its desired count
     for asset_kitsu_id, desired_count in asset_ids.items():
@@ -886,17 +826,6 @@ async def push_entities(
                     users,
                     entity_dict,
                 )
-        elif entity_dict["type"] == "CastingLink":
-            if project:
-                await sync_casting_link(
-                    addon,
-                    user,
-                    project,
-                    entity_dict,
-                    settings,
-                )
-            else:
-                logging.warning("CastingLink received without project context")
         elif entity_dict["type"] == "SyncCasting":
             if project:
                 await sync_casting(

--- a/server/kitsu/push.py
+++ b/server/kitsu/push.py
@@ -652,16 +652,36 @@ async def sync_casting(
     user: "UserEntity",
     project: "ProjectEntity",
     entity_dict: "EntityDict",
-    settings,
-):
-    """Sync casting links for a target (shot or asset) by reconciling
-    existing links with desired state from Kitsu.
+    settings: Any,
+) -> None:
+    """Sync casting links for a target (shot or asset) by reconciling existing
+    links with desired state from Kitsu.
     
-    This function:
-    1. Gets existing AYON links for the target
-    2. Compares with desired asset_ids from Kitsu
-    3. Deletes stale links (not in Kitsu anymore)
-    4. Creates missing links (new in Kitsu)
+    Perform full reconciliation of casting links:
+    1. Fetch existing AYON links for the target folder
+    2. Map existing links by asset Kitsu ID (from link data or folder lookup)
+    3. For each asset in Kitsu's desired state:
+       - Delete excess links if more exist in AYON than in Kitsu
+       - Create missing links if fewer exist in AYON than in Kitsu
+       - Each link includes occurence number in its data
+    4. Delete links for assets removed from Kitsu casting
+    
+    Handle multi-occurence casting by creating multiple links
+    with the same input/output/type but different occurence numbers.
+    
+    Args:
+        addon: KitsuAddon instance (unused but required by push_entities).
+        user: User entity for authentication when creating/deleting links.
+        project: AYON project entity.
+        entity_dict: SyncCasting entity dictionary containing:
+            - target_id: Kitsu ID of the shot or asset
+            - target_type: "Shot" or "Asset"
+            - asset_ids: Dictionary mapping asset Kitsu IDs to occurence counts
+            - ayon_server_url: Base URL for AYON API calls
+        settings: Addon settings containing sync_casting configuration.
+    
+    Returns:
+        None. Warnings for missing targets/assets and API failures.
     """
     if not settings.sync_settings.sync_casting.enabled:
         return

--- a/server/kitsu/push.py
+++ b/server/kitsu/push.py
@@ -17,11 +17,14 @@ from .constants import (
 )
 from .utils import (
     calculate_end_frame,
+    create_entity_link,
     create_folder,
     create_task,
+    delete_entity_link,
     delete_folder,
     delete_task,
     get_folder_by_kitsu_id,
+    get_links_for_output,
     get_task_by_kitsu_id,
     get_user_by_kitsu_id,
     update_project,
@@ -49,6 +52,8 @@ KitsuEntityType = Literal[
     "Task",
     "Person",
     "Project",
+    "CastingLink",
+    "SyncCasting",
 ]
 
 
@@ -586,6 +591,230 @@ async def sync_task(
             existing_tasks[entity_dict["id"]] = target_task.id
 
 
+async def sync_casting_link(
+    addon: "KitsuAddon",
+    user: "UserEntity",
+    project: "ProjectEntity",
+    entity_dict: "EntityDict",
+    settings,
+):
+    if not settings.sync_settings.sync_casting.enabled:
+        return
+
+    asset_kitsu_id = entity_dict.get("asset_id") or entity_dict.get("assetId")
+    target_kitsu_id = entity_dict.get("target_id") or entity_dict.get("targetId")
+    if not asset_kitsu_id or not target_kitsu_id:
+        logging.warning("CastingLink missing asset_id or target_id")
+        return
+
+    asset_folder = await get_folder_by_kitsu_id(
+        project.name,
+        asset_kitsu_id,
+    )
+    if not asset_folder:
+        logging.warning(
+            f"CastingLink asset not found for kitsuId {asset_kitsu_id}"
+        )
+        return
+
+    target_folder = await get_folder_by_kitsu_id(
+        project.name,
+        target_kitsu_id,
+    )
+    if not target_folder:
+        logging.warning(
+            f"CastingLink target not found for kitsuId {target_kitsu_id}"
+        )
+        return
+
+    link_type = (
+        settings.sync_settings.sync_casting.casting_link_type or "breakdown"
+    )
+    # Ensure link_type has proper format: name|input_type|output_type
+    if "|" not in link_type:
+        link_type = f"{link_type}|folder|folder"
+    await create_entity_link(
+        project_name=project.name,
+        user=user,
+        ayon_server_url=entity_dict["ayon_server_url"],
+        input_id=asset_folder.id,
+        output_id=target_folder.id,
+        link_type=link_type,
+        data={
+            "kitsuAssetId": asset_kitsu_id,
+            "kitsuTargetId": target_kitsu_id,
+        },
+    )
+
+
+async def sync_casting(
+    addon: "KitsuAddon",
+    user: "UserEntity",
+    project: "ProjectEntity",
+    entity_dict: "EntityDict",
+    settings,
+):
+    """Sync casting links for a target (shot or asset) by reconciling
+    existing links with desired state from Kitsu.
+    
+    This function:
+    1. Gets existing AYON links for the target
+    2. Compares with desired asset_ids from Kitsu
+    3. Deletes stale links (not in Kitsu anymore)
+    4. Creates missing links (new in Kitsu)
+    """
+    if not settings.sync_settings.sync_casting.enabled:
+        return
+
+    target_kitsu_id = entity_dict.get("target_id")
+    target_type = entity_dict.get("target_type", "Shot")
+    asset_ids = entity_dict.get("asset_ids", {})
+    
+    if not target_kitsu_id:
+        logging.warning("SyncCasting missing target_id")
+        return
+
+    # Get target folder (shot or asset)
+    target_folder = await get_folder_by_kitsu_id(
+        project.name,
+        target_kitsu_id,
+    )
+    if not target_folder:
+        logging.warning(
+            f"SyncCasting target not found for kitsuId {target_kitsu_id}"
+        )
+        return
+
+    # Get link type from settings
+    link_type = (
+        settings.sync_settings.sync_casting.casting_link_type or "breakdown"
+    )
+    # Ensure link_type has proper format: name|input_type|output_type
+    if "|" not in link_type:
+        link_type = f"{link_type}|folder|folder"
+
+    # Get existing AYON links for this target
+    existing_links = await get_links_for_output(
+        project.name,
+        target_folder.id,
+        link_type,
+    )
+
+    # Build mapping of asset_kitsu_id -> list of existing links
+    # Also map input_id -> asset_kitsu_id for lookup
+    existing_links_by_asset: dict[str, list[dict]] = {}
+    input_id_to_asset_kitsu_id: dict[str, str] = {}
+    
+    for link in existing_links:
+        # Try to get asset_kitsu_id from link data
+        link_data = link.get("data")
+        if link_data and isinstance(link_data, dict):
+            asset_kitsu_id = link_data.get("kitsuAssetId")
+        else:
+            asset_kitsu_id = None
+        
+        if not asset_kitsu_id:
+            # Fallback: try to find asset by input_id by querying the folder
+            input_id = link.get("input_id")
+            if input_id:
+                try:
+                    folder = await FolderEntity.load(project.name, input_id)
+                    asset_kitsu_id = folder.data.get("kitsuId")
+                except Exception:
+                    # Folder not found or no kitsuId, skip this link
+                    continue
+        
+        if asset_kitsu_id:
+            if asset_kitsu_id not in existing_links_by_asset:
+                existing_links_by_asset[asset_kitsu_id] = []
+            existing_links_by_asset[asset_kitsu_id].append(link)
+            input_id_to_asset_kitsu_id[link.get("input_id")] = asset_kitsu_id
+
+    # Process each asset with its desired count
+    for asset_kitsu_id, desired_count in asset_ids.items():
+        asset_folder = await get_folder_by_kitsu_id(
+            project.name,
+            asset_kitsu_id,
+        )
+        if not asset_folder:
+            logging.debug(
+                f"SyncCasting asset not found for kitsuId {asset_kitsu_id}, skipping"
+            )
+            continue
+
+        existing_count = len(existing_links_by_asset.get(asset_kitsu_id, []))
+        
+        # Delete excess links (more in AYON than in Kitsu)
+        if existing_count > desired_count:
+            links_to_delete = existing_links_by_asset[asset_kitsu_id][:existing_count - desired_count]
+            for link in links_to_delete:
+                await delete_entity_link(
+                    project_name=project.name,
+                    user=user,
+                    ayon_server_url=entity_dict["ayon_server_url"],
+                    link_id=link["id"],
+                )
+                logging.debug(
+                    f"Deleted excess casting link {link.get('input_id')}->{target_folder.id} "
+                    f"(asset {asset_kitsu_id}, had {existing_count}, need {desired_count})"
+                )
+        
+        # Create missing links (more in Kitsu than in AYON)
+        elif existing_count < desired_count:
+            for occurence_num in range(existing_count + 1, desired_count + 1):
+                await create_entity_link(
+                    project_name=project.name,
+                    user=user,
+                    ayon_server_url=entity_dict["ayon_server_url"],
+                    input_id=asset_folder.id,
+                    output_id=target_folder.id,
+                    link_type=link_type,
+                    data={
+                        "kitsuAssetId": asset_kitsu_id,
+                        "kitsuTargetId": target_kitsu_id,
+                        "occurence": occurence_num,
+                    },
+                )
+                logging.debug(
+                    f"Created casting link {asset_folder.name}->{target_folder.name} "
+                    f"(asset {asset_kitsu_id}, occurence {occurence_num}/{desired_count})"
+                )
+    
+    # Handle assets that were removed from Kitsu (exist in AYON but not in count dict)
+    # Find links for assets not in the count dict
+    for link in existing_links:
+        # Try to get asset_kitsu_id from link data
+        link_data = link.get("data")
+        if link_data and isinstance(link_data, dict):
+            asset_kitsu_id = link_data.get("kitsuAssetId")
+        else:
+            asset_kitsu_id = None
+        
+        if not asset_kitsu_id:
+            # Fallback: try to find asset by input_id
+            input_id = link.get("input_id")
+            if input_id:
+                try:
+                    folder = await FolderEntity.load(project.name, input_id)
+                    asset_kitsu_id = folder.data.get("kitsuId")
+                except Exception:
+                    # Folder not found, skip
+                    continue
+        
+        # If this asset is not in the asset_ids dict, it was removed from Kitsu
+        if asset_kitsu_id and asset_kitsu_id not in asset_ids:
+            await delete_entity_link(
+                project_name=project.name,
+                user=user,
+                ayon_server_url=entity_dict["ayon_server_url"],
+                link_id=link["id"],
+            )
+            logging.debug(
+                f"Deleted stale casting link {link.get('input_id')}->{target_folder.id} "
+                f"(asset {asset_kitsu_id} removed from Kitsu)"
+            )
+
+
 async def push_entities(
     addon: "KitsuAddon",
     user: "UserEntity",
@@ -637,6 +866,28 @@ async def push_entities(
                     users,
                     entity_dict,
                 )
+        elif entity_dict["type"] == "CastingLink":
+            if project:
+                await sync_casting_link(
+                    addon,
+                    user,
+                    project,
+                    entity_dict,
+                    settings,
+                )
+            else:
+                logging.warning("CastingLink received without project context")
+        elif entity_dict["type"] == "SyncCasting":
+            if project:
+                await sync_casting(
+                    addon,
+                    user,
+                    project,
+                    entity_dict,
+                    settings,
+                )
+            else:
+                logging.warning("SyncCasting received without project context")
         elif entity_dict["type"] != "Task":
             await sync_folder(
                 addon,

--- a/server/kitsu/push.py
+++ b/server/kitsu/push.py
@@ -597,9 +597,9 @@ async def sync_casting(
     entity_dict: "EntityDict",
     settings: Any,
 ) -> None:
-    """Sync casting links for a target (shot or asset) by reconciling existing
-    links with desired state from Kitsu.
-    
+    """Sync casting links for a target (shot or asset) by reconciling
+    existing links with desired state from Kitsu.
+
     Perform full reconciliation of casting links:
     1. Fetch existing AYON links for the target folder
     2. Map existing links by asset Kitsu ID (from link data or folder lookup)
@@ -608,10 +608,10 @@ async def sync_casting(
        - Create missing links if fewer exist in AYON than in Kitsu
        - Each link includes occurence number in its data
     4. Delete links for assets removed from Kitsu casting
-    
+
     Handle multi-occurence casting by creating multiple links
     with the same input/output/type but different occurence numbers.
-    
+
     Args:
         addon: KitsuAddon instance (unused but required by push_entities).
         user: User entity for authentication when creating/deleting links.
@@ -619,10 +619,11 @@ async def sync_casting(
         entity_dict: SyncCasting entity dictionary containing:
             - target_id: Kitsu ID of the shot or asset
             - target_type: "Shot" or "Asset"
-            - asset_ids: Dictionary mapping asset Kitsu IDs to occurence counts
+            - asset_ids: Dictionary mapping asset Kitsu IDs to occurence
+              counts
             - ayon_server_url: Base URL for AYON API calls
         settings: Addon settings containing sync_casting configuration.
-    
+
     Returns:
         None. Warnings for missing targets/assets and API failures.
     """
@@ -630,7 +631,6 @@ async def sync_casting(
         return
 
     target_kitsu_id = entity_dict.get("target_id")
-    target_type = entity_dict.get("target_type", "Shot")
     asset_ids = entity_dict.get("asset_ids", {})
 
     if not target_kitsu_id:
@@ -698,7 +698,8 @@ async def sync_casting(
         )
         if not asset_folder:
             logging.debug(
-                f"SyncCasting asset not found for kitsuId {asset_kitsu_id}, skipping"
+                f"SyncCasting asset not found for kitsuId "
+                f"{asset_kitsu_id}, skipping"
             )
             continue
 
@@ -706,7 +707,9 @@ async def sync_casting(
 
         # Delete excess links (more in AYON than in Kitsu)
         if existing_count > desired_count:
-            links_to_delete = existing_links_by_asset[asset_kitsu_id][:existing_count - desired_count]
+            links_to_delete = existing_links_by_asset[asset_kitsu_id][
+                : existing_count - desired_count
+            ]
             for link in links_to_delete:
                 await delete_entity_link(
                     project_name=project.name,
@@ -715,8 +718,10 @@ async def sync_casting(
                     link_id=link["id"],
                 )
                 logging.debug(
-                    f"Deleted excess casting link {link.get('input_id')}->{target_folder.id} "
-                    f"(asset {asset_kitsu_id}, had {existing_count}, need {desired_count})"
+                    f"Deleted excess casting link "
+                    f"{link.get('input_id')}->{target_folder.id} "
+                    f"(asset {asset_kitsu_id}, had {existing_count}, "
+                    f"need {desired_count})"
                 )
 
         # Create missing links (more in Kitsu than in AYON)
@@ -736,11 +741,14 @@ async def sync_casting(
                     },
                 )
                 logging.debug(
-                    f"Created casting link {asset_folder.name}->{target_folder.name} "
-                    f"(asset {asset_kitsu_id}, occurence {occurence_num}/{desired_count})"
+                    f"Created casting link "
+                    f"{asset_folder.name}->{target_folder.name} "
+                    f"(asset {asset_kitsu_id}, occurence "
+                    f"{occurence_num}/{desired_count})"
                 )
 
-    # Handle assets that were removed from Kitsu (exist in AYON but not in count dict)
+    # Handle assets that were removed from Kitsu
+    # (exist in AYON but not in count dict)
     # Find links for assets not in the count dict
     for link in existing_links:
         # Try to get asset_kitsu_id from link data
@@ -770,7 +778,8 @@ async def sync_casting(
                 link_id=link["id"],
             )
             logging.debug(
-                f"Deleted stale casting link {link.get('input_id')}->{target_folder.id} "
+                f"Deleted stale casting link "
+                f"{link.get('input_id')}->{target_folder.id} "
                 f"(asset {asset_kitsu_id} removed from Kitsu)"
             )
 

--- a/server/kitsu/utils.py
+++ b/server/kitsu/utils.py
@@ -1,5 +1,7 @@
 from typing import Any
 
+import httpx
+import re
 from nxtools import slugify, logging
 
 from ayon_server.entities import (
@@ -10,6 +12,8 @@ from ayon_server.entities import (
 )
 from ayon_server.events import dispatch_event
 from ayon_server.lib.postgres import Postgres
+from ayon_server.types import NAME_REGEX
+from ayon_server.auth.session import Session
 
 
 def calculate_end_frame(
@@ -268,6 +272,107 @@ async def delete_task(
     await dispatch_event(**event)
 
 
+def _ensure_safe_project_name(project_name: str) -> None:
+    """Validate project_name to prevent SQL injection in table names."""
+    if not re.fullmatch(NAME_REGEX, project_name):
+        raise ValueError(f"Invalid project name '{project_name}'")
+
+
+async def get_link_by_io(
+    project_name: str,
+    input_id: str,
+    output_id: str,
+    link_type: str,
+):
+    _ensure_safe_project_name(project_name)
+    res = await Postgres.fetch(
+        f"""
+        SELECT id FROM project_{project_name}.links
+        WHERE input_id = $1 AND output_id = $2 AND link_type = $3
+        """,
+        input_id,
+        output_id,
+        link_type,
+    )
+    if not res:
+        return None
+    return res[0]["id"]
+
+
+async def get_links_for_output(
+    project_name: str,
+    output_id: str,
+    link_type: str,
+):
+    _ensure_safe_project_name(project_name)
+    return await Postgres.fetch(
+        f"""
+        SELECT id, input_id, data FROM project_{project_name}.links
+        WHERE output_id = $1 AND link_type = $2
+        """,
+        output_id,
+        link_type,
+    )
+
+
+async def create_entity_link(
+    project_name: str,
+    user: "UserEntity",
+    ayon_server_url: str,
+    input_id: str,
+    output_id: str,
+    link_type: str,
+    data: dict | None = None,
+):
+    session = await Session.create(user)
+    headers = {"Authorization": f"Bearer {session.token}"}
+    payload: dict = {
+        "input": input_id,
+        "output": output_id,
+        "linkType": link_type,
+    }
+    if data:
+        payload["data"] = data
+
+    async with httpx.AsyncClient() as client:
+        res = await client.post(
+            f"{ayon_server_url}/api/projects/{project_name}/links",
+            json=payload,
+            headers=headers,
+        )
+    if res.status_code not in (200, 201):
+        logging.warning(
+            f"Failed to create link {input_id}->{output_id} "
+            f"type '{link_type}': {res.status_code} {res.text}"
+        )
+        return
+    try:
+        return res.json().get("id")
+    except Exception:
+        return None
+
+
+async def delete_entity_link(
+    project_name: str,
+    user: "UserEntity",
+    ayon_server_url: str,
+    link_id: str,
+):
+    session = await Session.create(user)
+    headers = {"Authorization": f"Bearer {session.token}"}
+
+    async with httpx.AsyncClient() as client:
+        res = await client.delete(
+            f"{ayon_server_url}/api/projects/{project_name}/links/{link_id}",
+            headers=headers,
+        )
+
+    if res.status_code not in (200, 204):
+        logging.warning(
+            f"Failed to delete link {link_id}: {res.status_code} {res.text}"
+        )
+
+
 async def update_project(
     name: str,
     **kwargs,
@@ -295,6 +400,8 @@ async def update_entity(
 
     if attr_whitelist is None:
         attr_whitelist = []
+
+    changed = False
 
     # keys that can be updated
     for key in attr_whitelist:

--- a/server/kitsu/utils.py
+++ b/server/kitsu/utils.py
@@ -283,7 +283,22 @@ async def get_link_by_io(
     input_id: str,
     output_id: str,
     link_type: str,
-):
+) -> str | None:
+    """Get a link ID by input/output IDs and link type.
+    
+    Query the database for an existing link matching the given input,
+    output, and link type. Return the first matching link's ID, or None
+    if no link exists.
+    
+    Args:
+        project_name: AYON project name (validated for SQL safety).
+        input_id: AYON folder ID of the link input (source).
+        output_id: AYON folder ID of the link output (target).
+        link_type: Link type identifier (e.g., "breakdown|folder|folder").
+    
+    Returns:
+        Link ID string if found, None otherwise.
+    """
     _ensure_safe_project_name(project_name)
     res = await Postgres.fetch(
         f"""
@@ -303,7 +318,23 @@ async def get_links_for_output(
     project_name: str,
     output_id: str,
     link_type: str,
-):
+) -> list[dict[str, Any]]:
+    """Get all links for a given output folder and link type.
+    
+    Query the database for all links where the specified folder is the
+    output (target). Return link metadata including ID, input_id, and data.
+    
+    Args:
+        project_name: AYON project name (validated for SQL safety).
+        output_id: AYON folder ID of the link output (target).
+        link_type: Link type identifier (e.g., "breakdown|folder|folder").
+    
+    Returns:
+        List of link dictionaries, each containing:
+            - id: Link ID
+            - input_id: AYON folder ID of the link input (source)
+            - data: Link data dictionary (may contain kitsuAssetId, etc.)
+    """
     _ensure_safe_project_name(project_name)
     return await Postgres.fetch(
         f"""
@@ -322,8 +353,29 @@ async def create_entity_link(
     input_id: str,
     output_id: str,
     link_type: str,
-    data: dict | None = None,
-):
+    data: dict[str, Any] | None = None,
+) -> str | None:
+    """Create an entity link via AYON REST API.
+    
+    Create a link between two folders (input and output) with the specified
+    link type. Multiple links with the same input/output/type are allowed
+    (e.g., for multi-occurence casting).
+    
+    Args:
+        project_name: AYON project name.
+        user: User entity for authentication.
+        ayon_server_url: Base URL of the AYON server.
+        input_id: AYON folder ID of the link input (source).
+        output_id: AYON folder ID of the link output (target).
+        link_type: Link type identifier in format "name|input_type|output_type"
+            (e.g., "breakdown|folder|folder").
+        data: Optional dictionary containing link metadata (e.g., kitsuAssetId,
+            kitsuTargetId, occurence).
+    
+    Returns:
+        Created link ID string if successful, None otherwise. Warnings
+        on failure.
+    """
     session = await Session.create(user)
     headers = {"Authorization": f"Bearer {session.token}"}
     payload: dict = {
@@ -357,7 +409,20 @@ async def delete_entity_link(
     user: "UserEntity",
     ayon_server_url: str,
     link_id: str,
-):
+) -> None:
+    """Delete an entity link via AYON REST API.
+    
+    Delete a link by its ID. Log warnings if the deletion fails.
+    
+    Args:
+        project_name: AYON project name.
+        user: User entity for authentication.
+        ayon_server_url: Base URL of the AYON server.
+        link_id: ID of the link to delete.
+    
+    Returns:
+        None. Warnings on failure.
+    """
     session = await Session.create(user)
     headers = {"Authorization": f"Bearer {session.token}"}
 

--- a/server/kitsu/utils.py
+++ b/server/kitsu/utils.py
@@ -285,17 +285,17 @@ async def get_link_by_io(
     link_type: str,
 ) -> str | None:
     """Get a link ID by input/output IDs and link type.
-    
+
     Query the database for an existing link matching the given input,
     output, and link type. Return the first matching link's ID, or None
     if no link exists.
-    
+
     Args:
         project_name: AYON project name (validated for SQL safety).
         input_id: AYON folder ID of the link input (source).
         output_id: AYON folder ID of the link output (target).
         link_type: Link type identifier (e.g., "breakdown|folder|folder").
-    
+
     Returns:
         Link ID string if found, None otherwise.
     """
@@ -320,15 +320,15 @@ async def get_links_for_output(
     link_type: str,
 ) -> list[dict[str, Any]]:
     """Get all links for a given output folder and link type.
-    
+
     Query the database for all links where the specified folder is the
     output (target). Return link metadata including ID, input_id, and data.
-    
+
     Args:
         project_name: AYON project name (validated for SQL safety).
         output_id: AYON folder ID of the link output (target).
         link_type: Link type identifier (e.g., "breakdown|folder|folder").
-    
+
     Returns:
         List of link dictionaries, each containing:
             - id: Link ID
@@ -356,11 +356,11 @@ async def create_entity_link(
     data: dict[str, Any] | None = None,
 ) -> str | None:
     """Create an entity link via AYON REST API.
-    
+
     Create a link between two folders (input and output) with the specified
     link type. Multiple links with the same input/output/type are allowed
     (e.g., for multi-occurence casting).
-    
+
     Args:
         project_name: AYON project name.
         user: User entity for authentication.
@@ -370,8 +370,8 @@ async def create_entity_link(
         link_type: Link type identifier in format "name|input_type|output_type"
             (e.g., "breakdown|folder|folder").
         data: Optional dictionary containing link metadata (e.g., kitsuAssetId,
-            kitsuTargetId, occurence).
-    
+            kitsuTargetId,             occurence).
+
     Returns:
         Created link ID string if successful, None otherwise. Warnings
         on failure.
@@ -411,15 +411,15 @@ async def delete_entity_link(
     link_id: str,
 ) -> None:
     """Delete an entity link via AYON REST API.
-    
+
     Delete a link by its ID. Log warnings if the deletion fails.
-    
+
     Args:
         project_name: AYON project name.
         user: User entity for authentication.
         ayon_server_url: Base URL of the AYON server.
         link_id: ID of the link to delete.
-    
+
     Returns:
         None. Warnings on failure.
     """

--- a/server/settings/sync_settings.py
+++ b/server/settings/sync_settings.py
@@ -88,6 +88,15 @@ class DefaultSyncInfo(BaseSettingsModel):
     )
 
 
+class SyncCasting(BaseSettingsModel):
+    enabled: bool = SettingsField(False, title="Sync casting links")
+    casting_link_type: str = SettingsField(
+        "breakdown",
+        title="Casting link type",
+        regex=NAME_REGEX,
+    )
+
+
 class SyncSettings(BaseSettingsModel):
     """Enabling 'Delete projects' will remove projects on Ayon when they get deleted on Kitsu"""
 
@@ -95,6 +104,10 @@ class SyncSettings(BaseSettingsModel):
     sync_users: SyncUsers = SettingsField(
         default_factory=SyncUsers,
         title="Sync users",
+    )
+    sync_casting: SyncCasting = SettingsField(
+        default_factory=SyncCasting,
+        title="Sync casting",
     )
     default_sync_info: DefaultSyncInfo = SettingsField(
         default_factory=DefaultSyncInfo,
@@ -108,6 +121,10 @@ SYNC_DEFAULT_VALUES = {
         "enabled": False,
         "default_password": "default_password",
         "access_group": "kitsu_group",
+    },
+    "sync_casting": {
+        "enabled": False,
+        "casting_link_type": "breakdown",
     },
     "default_sync_info": {
         "default_task_info": [

--- a/services/processor/processor/fullsync.py
+++ b/services/processor/processor/fullsync.py
@@ -46,6 +46,92 @@ def get_tasks(
     return tasks
 
 
+def get_casting_links(
+    shots: list[dict],
+    assets: list[dict],
+) -> list[dict[str, str]]:
+    """Get casting links for shots and assets.
+    
+    Groups casting by target and creates SyncCasting entities for full
+    reconciliation (including deletion of stale links).
+    
+    Args:
+        shots: List of shot dicts from gazu
+        assets: List of asset dicts from gazu
+        
+    Returns:
+        List of SyncCasting entity dicts
+    """
+    casting_entities: list[dict[str, str]] = []
+    
+    # Get casting for shots (which assets are in each shot)
+    for shot in shots:
+        shot_id = shot.get("id")
+        if not shot_id:
+            continue
+        try:
+            casting = gazu.casting.get_shot_casting(shot)
+        except Exception as e:
+            logging.debug(f"Unable to fetch casting for shot {shot_id}: {e}")
+            continue
+        
+        # Extract asset_ids with occurence count
+        asset_ids: dict[str, int] = {}
+        for item in casting or []:
+            if isinstance(item, dict):
+                asset_id = item.get("asset_id")
+                nb_occurences = item.get("nb_occurences", 1)
+            else:
+                asset_id = item
+                nb_occurences = 1
+            if asset_id:
+                asset_ids[asset_id] = asset_ids.get(asset_id, 0) + nb_occurences
+        
+        # Create SyncCasting entity for this shot
+        casting_entities.append({
+            "id": f"sync-casting-{shot_id}",
+            "type": "SyncCasting",
+            "target_id": shot_id,
+            "target_type": "Shot",
+            "asset_ids": asset_ids,
+        })
+    
+    # Get casting for assets (asset dependencies / nested assets)
+    for asset in assets:
+        asset_id = asset.get("id")
+        if not asset_id:
+            continue
+        try:
+            casting = gazu.casting.get_asset_casting(asset)
+        except Exception as e:
+            logging.debug(f"Unable to fetch casting for asset {asset_id}: {e}")
+            continue
+        
+        # Extract asset_ids with occurence count
+        asset_ids: dict[str, int] = {}
+        for item in casting or []:
+            if isinstance(item, dict):
+                linked_asset_id = item.get("asset_id")
+                nb_occurences = item.get("nb_occurences", 1)
+            else:
+                linked_asset_id = item
+                nb_occurences = 1
+            if linked_asset_id:
+                asset_ids[linked_asset_id] = asset_ids.get(linked_asset_id, 0) + nb_occurences
+        
+        # Create SyncCasting entity for this asset
+        casting_entities.append({
+            "id": f"sync-casting-{asset_id}",
+            "type": "SyncCasting",
+            "target_id": asset_id,
+            "target_type": "Asset",
+            "asset_ids": asset_ids,
+        })
+    
+    logging.debug(f"Found {len(casting_entities)} SyncCasting entities")
+    return casting_entities
+
+
 def project_full_sync(
     parent: "KitsuProcessor", kitsu_project_id: str, project_name: str
 ):
@@ -58,7 +144,6 @@ def project_full_sync(
     """
     start_time = time.time()
     logging.info(f"Syncing kitsu project {kitsu_project_id} to {project_name}")
-
     asset_types = get_asset_types(kitsu_project_id)
     task_statuses = get_statuses()
     task_types = get_task_types(kitsu_project_id)
@@ -66,6 +151,11 @@ def project_full_sync(
 
     assets = get_assets(kitsu_project_id, asset_types)
     tasks = get_tasks(kitsu_project_id, task_types, task_statuses)
+    sync_casting_settings = (
+        parent.settings.get("sync_settings", {})
+        .get("sync_casting", {})
+    )
+    casting_enabled = sync_casting_settings.get("enabled", False)
 
     episodes = gazu.shot.all_episodes_for_project(kitsu_project_id)
     seqs = gazu.shot.all_sequences_for_project(kitsu_project_id)
@@ -82,6 +172,8 @@ def project_full_sync(
     entities = (
         persons + assets + episodes + seqs + shots + edits + concepts + tasks
     )
+    if casting_enabled:
+        entities += get_casting_links(shots, assets)
 
     for entity in entities:
         entity["ayon_server_url"] = ayon_api.get_base_url()

--- a/services/processor/processor/fullsync.py
+++ b/services/processor/processor/fullsync.py
@@ -51,18 +51,19 @@ def get_casting_links(
     assets: list[dict[str, Any]],
 ) -> list[dict[str, Any]]:
     """Get casting links for shots and assets.
-    
+
     Fetche casting data from Kitsu for all shots and assets, group them by
     target entity, and create SyncCasting entities. Each SyncCasting entity
     contains the complete desired state (asset_ids with occurence counts) for
     full reconciliation, including deletion of stale links.
-    
+
     Args:
-        shots: List of shot dictionaries from gazu API, each containing at least
+        shots: List of shot dictionaries from gazu API, each containing at
+            least
             an "id" field.
         assets: List of asset dictionaries from gazu API, each containing at
             least an "id" field.
-        
+
     Returns:
         List of SyncCasting entity dictionaries. Each entity contains:
             - id: Unique identifier (format: "sync-casting-{target_id}")
@@ -94,7 +95,9 @@ def get_casting_links(
                 asset_id = item
                 nb_occurences = 1
             if asset_id:
-                asset_ids[asset_id] = asset_ids.get(asset_id, 0) + nb_occurences
+                asset_ids[asset_id] = (
+                    asset_ids.get(asset_id, 0) + nb_occurences
+                )
 
         # Create SyncCasting entity for this shot
         casting_entities.append({
@@ -126,7 +129,9 @@ def get_casting_links(
                 linked_asset_id = item
                 nb_occurences = 1
             if linked_asset_id:
-                asset_ids[linked_asset_id] = asset_ids.get(linked_asset_id, 0) + nb_occurences
+                asset_ids[linked_asset_id] = (
+                    asset_ids.get(linked_asset_id, 0) + nb_occurences
+                )
 
         # Create SyncCasting entity for this asset
         casting_entities.append({

--- a/services/processor/processor/fullsync.py
+++ b/services/processor/processor/fullsync.py
@@ -72,7 +72,7 @@ def get_casting_links(
             - asset_ids: Dictionary mapping asset Kitsu IDs to occurence counts
     """
     casting_entities: list[dict[str, Any]] = []
-    
+
     # Get casting for shots (which assets are in each shot)
     for shot in shots:
         shot_id = shot.get("id")
@@ -83,7 +83,7 @@ def get_casting_links(
         except Exception as e:
             logging.debug(f"Unable to fetch casting for shot {shot_id}: {e}")
             continue
-        
+
         # Extract asset_ids with occurence count
         asset_ids: dict[str, int] = {}
         for item in casting or []:
@@ -95,7 +95,7 @@ def get_casting_links(
                 nb_occurences = 1
             if asset_id:
                 asset_ids[asset_id] = asset_ids.get(asset_id, 0) + nb_occurences
-        
+
         # Create SyncCasting entity for this shot
         casting_entities.append({
             "id": f"sync-casting-{shot_id}",
@@ -104,7 +104,7 @@ def get_casting_links(
             "target_type": "Shot",
             "asset_ids": asset_ids,
         })
-    
+
     # Get casting for assets (asset dependencies / nested assets)
     for asset in assets:
         asset_id = asset.get("id")
@@ -115,7 +115,7 @@ def get_casting_links(
         except Exception as e:
             logging.debug(f"Unable to fetch casting for asset {asset_id}: {e}")
             continue
-        
+
         # Extract asset_ids with occurence count
         asset_ids: dict[str, int] = {}
         for item in casting or []:
@@ -127,7 +127,7 @@ def get_casting_links(
                 nb_occurences = 1
             if linked_asset_id:
                 asset_ids[linked_asset_id] = asset_ids.get(linked_asset_id, 0) + nb_occurences
-        
+
         # Create SyncCasting entity for this asset
         casting_entities.append({
             "id": f"sync-casting-{asset_id}",
@@ -136,7 +136,7 @@ def get_casting_links(
             "target_type": "Asset",
             "asset_ids": asset_ids,
         })
-    
+
     logging.debug(f"Found {len(casting_entities)} SyncCasting entities")
     return casting_entities
 

--- a/services/processor/processor/fullsync.py
+++ b/services/processor/processor/fullsync.py
@@ -1,5 +1,5 @@
 import time
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 import ayon_api
 import gazu
@@ -47,22 +47,31 @@ def get_tasks(
 
 
 def get_casting_links(
-    shots: list[dict],
-    assets: list[dict],
-) -> list[dict[str, str]]:
+    shots: list[dict[str, Any]],
+    assets: list[dict[str, Any]],
+) -> list[dict[str, Any]]:
     """Get casting links for shots and assets.
     
-    Groups casting by target and creates SyncCasting entities for full
-    reconciliation (including deletion of stale links).
+    Fetche casting data from Kitsu for all shots and assets, group them by
+    target entity, and create SyncCasting entities. Each SyncCasting entity
+    contains the complete desired state (asset_ids with occurence counts) for
+    full reconciliation, including deletion of stale links.
     
     Args:
-        shots: List of shot dicts from gazu
-        assets: List of asset dicts from gazu
+        shots: List of shot dictionaries from gazu API, each containing at least
+            an "id" field.
+        assets: List of asset dictionaries from gazu API, each containing at
+            least an "id" field.
         
     Returns:
-        List of SyncCasting entity dicts
+        List of SyncCasting entity dictionaries. Each entity contains:
+            - id: Unique identifier (format: "sync-casting-{target_id}")
+            - type: "SyncCasting"
+            - target_id: Kitsu ID of the shot or asset
+            - target_type: "Shot" or "Asset"
+            - asset_ids: Dictionary mapping asset Kitsu IDs to occurence counts
     """
-    casting_entities: list[dict[str, str]] = []
+    casting_entities: list[dict[str, Any]] = []
     
     # Get casting for shots (which assets are in each shot)
     for shot in shots:

--- a/services/processor/processor/processor.py
+++ b/services/processor/processor/processor.py
@@ -18,6 +18,7 @@ from .update_from_kitsu import (
     create_or_update_sequence,
     create_or_update_shot,
     create_or_update_task,
+    create_or_update_casting,
     delete_asset,
     delete_concept,
     delete_edit,
@@ -203,6 +204,11 @@ class KitsuProcessor:
             self.event_client,
             "shot:update",
             lambda data: create_or_update_shot(self, data),
+        )
+        gazu.events.add_listener(
+            self.event_client,
+            "shot:casting-update",
+            lambda data: create_or_update_casting(self, data),
         )
         gazu.events.add_listener(
             self.event_client,

--- a/services/processor/processor/processor.py
+++ b/services/processor/processor/processor.py
@@ -212,6 +212,11 @@ class KitsuProcessor:
         )
         gazu.events.add_listener(
             self.event_client,
+            "asset:casting-update",
+            lambda data: create_or_update_casting(self, data),
+        )
+        gazu.events.add_listener(
+            self.event_client,
             "shot:delete",
             lambda data: delete_shot(self, data),
         )

--- a/services/processor/processor/update_from_kitsu.py
+++ b/services/processor/processor/update_from_kitsu.py
@@ -342,7 +342,7 @@ def create_or_update_casting(
 
     Process real-time casting update events from Kitsu (shot:casting-update
     or asset:casting-update). Fetch the current casting state from Kitsu,
-    creat a SyncCasting entity with the complete desired state, and push
+    create a SyncCasting entity with the complete desired state, and push
     it to AYON for reconciliation.
 
     Args:

--- a/services/processor/processor/update_from_kitsu.py
+++ b/services/processor/processor/update_from_kitsu.py
@@ -355,7 +355,6 @@ def create_or_update_casting(
             One of the following is required:
             - shot_id: Shot ID for shot casting updates
             - asset_id: Asset ID for asset casting updates
-            - entity_id: Generic entity ID (type will be detected)
 
     Returns:
         None. The function logs warnings and returns early if:
@@ -391,15 +390,6 @@ def create_or_update_casting(
     elif data.get("asset_id"):
         target_id = data["asset_id"]
         target_type = "Asset"
-    # Fallback: entity_id might be present (need to determine type)
-    elif data.get("entity_id"):
-        target_id = data["entity_id"]
-        # Try to determine if it's a shot or asset by attempting to fetch it
-        try:
-            gazu.shot.get_shot(target_id)
-            target_type = "Shot"
-        except Exception:
-            target_type = "Asset"
 
     if not target_id:
         logging.warning(f"Casting event missing target identifier: {data}")

--- a/services/processor/processor/update_from_kitsu.py
+++ b/services/processor/processor/update_from_kitsu.py
@@ -336,36 +336,55 @@ def delete_person(parent: "KitsuProcessor", data: dict[str, str]):
 
 
 def create_or_update_casting(parent: "KitsuProcessor", data: dict[str, str]):
-    logging.info(f"create_or_update_casting: {data}")
+    logging.info(f"create_or_update_casting received event: {data}")
     sync_casting_settings = (
         parent.settings.get("sync_settings", {})
         .get("sync_casting", {})
     )
     if not sync_casting_settings.get("enabled", False):
+        logging.debug("Casting sync is disabled, skipping")
         return
-    project_name = parent.get_paired_ayon_project(data["project_id"])
+    project_name = parent.get_paired_ayon_project(data.get("project_id"))
     if not project_name:
+        logging.debug(f"Project {data.get('project_id')} not paired, skipping")
         return
 
-    # Determine if this is a shot or asset casting update
-    shot_id = data.get("shot_id") or data.get("entity_id") or data.get("id")
-    asset_id = data.get("asset_id")
-    target_type = "Shot"
-    target_id = shot_id
+    # Determine the target entity (shot or asset whose casting is being updated)
+    # Kitsu sends different fields depending on the event type
+    # Priority: explicit shot_id/asset_id > entity_id (with type detection)
+    target_id = None
+    target_type = None
     
-    if asset_id and not shot_id:
-        # This is an asset casting update (asset dependencies)
+    # For shot:casting-update, Kitsu sends shot_id explicitly
+    if data.get("shot_id"):
+        target_id = data["shot_id"]
+        target_type = "Shot"
+    # For asset:casting-update, Kitsu sends asset_id explicitly
+    elif data.get("asset_id"):
+        target_id = data["asset_id"]
         target_type = "Asset"
-        target_id = asset_id
-    elif not shot_id:
-        logging.warning("Casting event missing shot_id or asset_id")
+    # Fallback: entity_id might be present (need to determine type)
+    elif data.get("entity_id"):
+        target_id = data["entity_id"]
+        # Try to determine if it's a shot or asset by attempting to fetch it
+        try:
+            gazu.shot.get_shot(target_id)
+            target_type = "Shot"
+        except Exception:
+            target_type = "Asset"
+    
+    if not target_id:
+        logging.warning(f"Casting event missing target identifier: {data}")
         return
+    
+    logging.info(f"Processing casting update for {target_type} {target_id}")
 
     entities: list[dict[str, str]] = []
     
     try:
         if target_type == "Shot":
-            casting = gazu.casting.get_shot_casting(target_id)
+            shot = gazu.shot.get_shot(target_id)
+            casting = gazu.casting.get_shot_casting(shot)
         else:
             # Asset casting
             asset = gazu.asset.get_asset(target_id)
@@ -395,7 +414,7 @@ def create_or_update_casting(parent: "KitsuProcessor", data: dict[str, str]):
         "target_id": target_id,
         "target_type": target_type,
         "asset_ids": asset_ids,
-        "project_id": data["project_id"],
+        "project_id": data.get("project_id"),
         "ayon_server_url": ayon_api.get_base_url(),
     }
     entities.append(entity)

--- a/services/processor/processor/update_from_kitsu.py
+++ b/services/processor/processor/update_from_kitsu.py
@@ -376,37 +376,33 @@ def create_or_update_casting(
         logging.debug(f"Project {data.get('project_id')} not paired, skipping")
         return
 
-    # Determine the target entity (shot or asset whose casting is updated)
     # Kitsu sends different fields depending on the event type
-    # Priority: explicit shot_id/asset_id > entity_id (with type detection)
-    target_id = None
-    target_type = None
-
     # For shot:casting-update, Kitsu sends shot_id explicitly
+    target_id = None
     if data.get("shot_id"):
         target_id = data["shot_id"]
-        target_type = "Shot"
     # For asset:casting-update, Kitsu sends asset_id explicitly
     elif data.get("asset_id"):
         target_id = data["asset_id"]
-        target_type = "Asset"
 
     if not target_id:
         logging.warning(f"Casting event missing target identifier: {data}")
         return
 
-    logging.info(f"Processing casting update for {target_type} {target_id}")
-
-    entities: list[dict[str, Any]] = []
-
     try:
+        entity = gazu.entity.get_entity(target_id)
+        target_type = entity["type"]
+        logging.info(f"Processing casting update for {target_type} {target_id}")
         if target_type == "Shot":
-            shot = gazu.shot.get_shot(target_id)
-            casting = gazu.casting.get_shot_casting(shot)
+            casting = gazu.casting.get_shot_casting(entity)
+        elif target_type == "Asset":
+            casting = gazu.casting.get_asset_casting(entity)
         else:
-            # Asset casting
-            asset = gazu.asset.get_asset(target_id)
-            casting = gazu.casting.get_asset_casting(asset)
+            logging.warning(
+                f"Unable to fetch casting for {target_type.lower()} "
+                f"{target_id}: unsupported entity type {entity['type']}"
+            )
+            return
     except Exception as e:
         logging.warning(
             f"Unable to fetch casting for {target_type.lower()} "
@@ -433,11 +429,8 @@ def create_or_update_casting(
         "project_id": data.get("project_id"),
         "ayon_server_url": ayon_api.get_base_url(),
     }
-    entities.append(entity)
-
-    if entities:
-        return ayon_api.post(
-            f"{parent.entrypoint}/push",
-            project_name=project_name,
-            entities=entities,
-        )
+    return ayon_api.post(
+        f"{parent.entrypoint}/push",
+        project_name=project_name,
+        entities=[entity],
+    )

--- a/services/processor/processor/update_from_kitsu.py
+++ b/services/processor/processor/update_from_kitsu.py
@@ -339,12 +339,12 @@ def create_or_update_casting(
     parent: "KitsuProcessor", data: dict[str, Any]
 ) -> None:
     """Handle casting update events from Kitsu.
-    
+
     Process real-time casting update events from Kitsu (shot:casting-update
     or asset:casting-update). Fetch the current casting state from Kitsu,
     creat a SyncCasting entity with the complete desired state, and push
     it to AYON for reconciliation.
-    
+
     Args:
         parent: KitsuProcessor instance with settings and project pairing info.
         data: Event data dictionary from Kitsu containing:
@@ -352,7 +352,7 @@ def create_or_update_casting(
             - shot_id: (optional) Shot ID for shot casting updates
             - asset_id: (optional) Asset ID for asset casting updates
             - entity_id: (optional) Generic entity ID (type will be detected)
-    
+
     Returns:
         None. The function logs warnings and returns early if:
         - Casting sync is disabled in settings
@@ -373,7 +373,7 @@ def create_or_update_casting(
         logging.debug(f"Project {data.get('project_id')} not paired, skipping")
         return
 
-    # Determine the target entity (shot or asset whose casting is being updated)
+    # Determine the target entity (shot or asset whose casting is updated)
     # Kitsu sends different fields depending on the event type
     # Priority: explicit shot_id/asset_id > entity_id (with type detection)
     target_id = None
@@ -415,7 +415,8 @@ def create_or_update_casting(
             casting = gazu.casting.get_asset_casting(asset)
     except Exception as e:
         logging.warning(
-            f"Unable to fetch casting for {target_type.lower()} {target_id}: {e}"
+            f"Unable to fetch casting for {target_type.lower()} "
+            f"{target_id}: {e}"
         )
         return
 
@@ -429,7 +430,9 @@ def create_or_update_casting(
             item_asset_id = item
             nb_occurences = 1
         if item_asset_id:
-            asset_ids[item_asset_id] = asset_ids.get(item_asset_id, 0) + nb_occurences
+            asset_ids[item_asset_id] = (
+                asset_ids.get(item_asset_id, 0) + nb_occurences
+            )
 
     # Create SyncCasting entity with complete state
     entity = {

--- a/services/processor/processor/update_from_kitsu.py
+++ b/services/processor/processor/update_from_kitsu.py
@@ -345,13 +345,17 @@ def create_or_update_casting(
     create a SyncCasting entity with the complete desired state, and push
     it to AYON for reconciliation.
 
+    NB: currently only supports shot casting updates.
+    https://github.com/cgwire/zou/issues/392
+
     Args:
         parent: KitsuProcessor instance with settings and project pairing info.
         data: Event data dictionary from Kitsu containing:
             - project_id: Kitsu project ID
-            - shot_id: (optional) Shot ID for shot casting updates
-            - asset_id: (optional) Asset ID for asset casting updates
-            - entity_id: (optional) Generic entity ID (type will be detected)
+            One of the following is required:
+            - shot_id: Shot ID for shot casting updates
+            - asset_id: Asset ID for asset casting updates
+            - entity_id: Generic entity ID (type will be detected)
 
     Returns:
         None. The function logs warnings and returns early if:
@@ -422,17 +426,12 @@ def create_or_update_casting(
 
     # Extract asset_ids with occurence count
     asset_ids: dict[str, int] = {}
-    for item in casting or []:
-        if isinstance(item, dict):
-            item_asset_id = item.get("asset_id")
-            nb_occurences = item.get("nb_occurences", 1)
-        else:
-            item_asset_id = item
-            nb_occurences = 1
-        if item_asset_id:
-            asset_ids[item_asset_id] = (
-                asset_ids.get(item_asset_id, 0) + nb_occurences
-            )
+    for actor in casting:
+        actor_asset_id = actor.get("asset_id")
+        if actor_asset_id:
+            asset_ids[actor_asset_id] = asset_ids.get(
+                actor_asset_id, 0
+            ) + actor.get("nb_occurences", 1)
 
     # Create SyncCasting entity with complete state
     entity = {

--- a/services/processor/processor/update_from_kitsu.py
+++ b/services/processor/processor/update_from_kitsu.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 import ayon_api
 import gazu
@@ -335,7 +335,31 @@ def delete_person(parent: "KitsuProcessor", data: dict[str, str]):
     )
 
 
-def create_or_update_casting(parent: "KitsuProcessor", data: dict[str, str]):
+def create_or_update_casting(
+    parent: "KitsuProcessor", data: dict[str, Any]
+) -> None:
+    """Handle casting update events from Kitsu.
+    
+    Process real-time casting update events from Kitsu (shot:casting-update
+    or asset:casting-update). Fetch the current casting state from Kitsu,
+    creat a SyncCasting entity with the complete desired state, and push
+    it to AYON for reconciliation.
+    
+    Args:
+        parent: KitsuProcessor instance with settings and project pairing info.
+        data: Event data dictionary from Kitsu containing:
+            - project_id: Kitsu project ID
+            - shot_id: (optional) Shot ID for shot casting updates
+            - asset_id: (optional) Asset ID for asset casting updates
+            - entity_id: (optional) Generic entity ID (type will be detected)
+    
+    Returns:
+        None. The function logs warnings and returns early if:
+        - Casting sync is disabled in settings
+        - Project is not paired with an AYON project
+        - Target entity cannot be determined
+        - Casting data cannot be fetched from Kitsu
+    """
     logging.info(f"create_or_update_casting received event: {data}")
     sync_casting_settings = (
         parent.settings.get("sync_settings", {})
@@ -379,7 +403,7 @@ def create_or_update_casting(parent: "KitsuProcessor", data: dict[str, str]):
     
     logging.info(f"Processing casting update for {target_type} {target_id}")
 
-    entities: list[dict[str, str]] = []
+    entities: list[dict[str, Any]] = []
     
     try:
         if target_type == "Shot":

--- a/services/processor/processor/update_from_kitsu.py
+++ b/services/processor/processor/update_from_kitsu.py
@@ -333,3 +333,76 @@ def delete_person(parent: "KitsuProcessor", data: dict[str, str]):
         project_name=project_name,
         entities=[entity],
     )
+
+
+def create_or_update_casting(parent: "KitsuProcessor", data: dict[str, str]):
+    logging.info(f"create_or_update_casting: {data}")
+    sync_casting_settings = (
+        parent.settings.get("sync_settings", {})
+        .get("sync_casting", {})
+    )
+    if not sync_casting_settings.get("enabled", False):
+        return
+    project_name = parent.get_paired_ayon_project(data["project_id"])
+    if not project_name:
+        return
+
+    # Determine if this is a shot or asset casting update
+    shot_id = data.get("shot_id") or data.get("entity_id") or data.get("id")
+    asset_id = data.get("asset_id")
+    target_type = "Shot"
+    target_id = shot_id
+    
+    if asset_id and not shot_id:
+        # This is an asset casting update (asset dependencies)
+        target_type = "Asset"
+        target_id = asset_id
+    elif not shot_id:
+        logging.warning("Casting event missing shot_id or asset_id")
+        return
+
+    entities: list[dict[str, str]] = []
+    
+    try:
+        if target_type == "Shot":
+            casting = gazu.casting.get_shot_casting(target_id)
+        else:
+            # Asset casting
+            asset = gazu.asset.get_asset(target_id)
+            casting = gazu.casting.get_asset_casting(asset)
+    except Exception as e:
+        logging.warning(
+            f"Unable to fetch casting for {target_type.lower()} {target_id}: {e}"
+        )
+        return
+
+    # Extract asset_ids with occurence count
+    asset_ids: dict[str, int] = {}
+    for item in casting or []:
+        if isinstance(item, dict):
+            item_asset_id = item.get("asset_id")
+            nb_occurences = item.get("nb_occurences", 1)
+        else:
+            item_asset_id = item
+            nb_occurences = 1
+        if item_asset_id:
+            asset_ids[item_asset_id] = asset_ids.get(item_asset_id, 0) + nb_occurences
+
+    # Create SyncCasting entity with complete state
+    entity = {
+        "id": f"sync-casting-{target_id}",
+        "type": "SyncCasting",
+        "target_id": target_id,
+        "target_type": target_type,
+        "asset_ids": asset_ids,
+        "project_id": data["project_id"],
+        "ayon_server_url": ayon_api.get_base_url(),
+    }
+    entities.append(entity)
+
+    if entities:
+        return ayon_api.post(
+            f"{parent.entrypoint}/push",
+            project_name=project_name,
+            entities=entities,
+        )

--- a/services/processor/processor/update_from_kitsu.py
+++ b/services/processor/processor/update_from_kitsu.py
@@ -378,7 +378,7 @@ def create_or_update_casting(
     # Priority: explicit shot_id/asset_id > entity_id (with type detection)
     target_id = None
     target_type = None
-    
+
     # For shot:casting-update, Kitsu sends shot_id explicitly
     if data.get("shot_id"):
         target_id = data["shot_id"]
@@ -396,15 +396,15 @@ def create_or_update_casting(
             target_type = "Shot"
         except Exception:
             target_type = "Asset"
-    
+
     if not target_id:
         logging.warning(f"Casting event missing target identifier: {data}")
         return
-    
+
     logging.info(f"Processing casting update for {target_type} {target_id}")
 
     entities: list[dict[str, Any]] = []
-    
+
     try:
         if target_type == "Shot":
             shot = gazu.shot.get_shot(target_id)

--- a/services/processor/processor/update_from_kitsu.py
+++ b/services/processor/processor/update_from_kitsu.py
@@ -392,7 +392,9 @@ def create_or_update_casting(
     try:
         entity = gazu.entity.get_entity(target_id)
         target_type = entity["type"]
-        logging.info(f"Processing casting update for {target_type} {target_id}")
+        logging.info(
+            f"Processing casting update for {target_type} {target_id}"
+        )
         if target_type == "Shot":
             casting = gazu.casting.get_shot_casting(entity)
         elif target_type == "Asset":

--- a/services/processor/pyproject.toml
+++ b/services/processor/pyproject.toml
@@ -7,7 +7,7 @@ package-mode = false
 
 [tool.poetry.dependencies]
 python = "^3.11"
-gazu = "^0.9.9"
+gazu = "^1.1.1"
 nxtools = "^1.6"
 ayon-python-api = "1.0.0rc3"
 

--- a/services/processor/pyproject.toml
+++ b/services/processor/pyproject.toml
@@ -7,7 +7,7 @@ package-mode = false
 
 [tool.poetry.dependencies]
 python = "^3.11"
-gazu = "^1.1.1"
+gazu = "^0.9.9"
 nxtools = "^1.6"
 ayon-python-api = "1.0.0rc3"
 


### PR DESCRIPTION
## Changelog Description
Add sync process and listener for casting breakdown in Kitsu.

## Additional review information
It creates Ayon `breakdown` links by default.

**NB: works only for shot casting update for now! See https://github.com/cgwire/gazu/issues/393**

## Testing notes:
1. Make sure a project is paired
2. Push the addon
3. Set it to your bundle
4. Enable the sync setting
5. Start a worker with this version (local or docker)
6. After fullsync, you should see breakdown links.
7. When the listener is running, you can add or remove casting in Kitsu to see them synced in real time.
