### PR TITLE
Bugfix: Kitsu credentials active in CLI

### DIFF
--- a/client/ayon_kitsu/addon.py
+++ b/client/ayon_kitsu/addon.py
@@ -84,7 +84,9 @@ class KitsuAddon(AYONAddon, IPluginPaths, ITrayAction):
                 "Please fill them via the Kitsu Connect tray action."
             )
 
-        if not validate_credentials(login, password, kitsu_url=self.server_url):
+        if not validate_credentials(
+            login, password, kitsu_url=self.server_url
+        ):
             raise ProcessPreparationError(
                 "Kitsu credentials are invalid. "
                 "Please update them via the Kitsu Connect tray action."

--- a/client/ayon_kitsu/addon.py
+++ b/client/ayon_kitsu/addon.py
@@ -55,12 +55,10 @@ class KitsuAddon(AYONAddon, IPluginPaths, ITrayAction):
         )
 
         login, password = load_credentials()
-
         if login is None or password is None:
-            # TODO raise correct type
-            raise
+            self.show_dialog()
+            return
 
-        # Check credentials, ask them if needed
         if validate_credentials(login, password):
             set_credentials_envs(login, password)
         else:
@@ -68,18 +66,30 @@ class KitsuAddon(AYONAddon, IPluginPaths, ITrayAction):
 
     def get_global_environments(self):
         """Kitsu's global environments."""
-        env = {"KITSU_SERVER": self.server_url}
+        return {"KITSU_SERVER": self.server_url}
 
-        # Load Kitsu credentials from secure registry and add to environment
-        from .credentials import load_credentials
+    def ensure_is_process_ready(self, process_context):
+        """Block process launch if Kitsu credentials are missing or invalid."""
+        from ayon_core.addon import ProcessPreparationError
+        from .credentials import (
+            load_credentials,
+            validate_credentials,
+            set_credentials_envs,
+        )
 
         login, password = load_credentials()
-        if login is not None:
-            env["KITSU_LOGIN"] = login
-        if password is not None:
-            env["KITSU_PWD"] = password
+        if login is None or password is None:
+            raise ProcessPreparationError(
+                "Kitsu credentials are not set. "
+                "Please fill them via the Kitsu Connect tray action."
+            )
 
-        return env
+        if not validate_credentials(login, password, kitsu_url=self.server_url):
+            raise ProcessPreparationError(
+                "Kitsu credentials are invalid. "
+                "Please update them via the Kitsu Connect tray action."
+            )
+        set_credentials_envs(login, password)
 
     def _get_dialog(self):
         if self._dialog is None:

--- a/client/ayon_kitsu/addon.py
+++ b/client/ayon_kitsu/addon.py
@@ -69,17 +69,16 @@ class KitsuAddon(AYONAddon, IPluginPaths, ITrayAction):
     def get_global_environments(self):
         """Kitsu's global environments."""
         env = {"KITSU_SERVER": self.server_url}
-        
+
         # Load Kitsu credentials from secure registry and add to environment
-        # This ensures CLI launches (like ayon-launch-scripts) have access to credentials
         from .credentials import load_credentials
-        
+
         login, password = load_credentials()
         if login is not None:
             env["KITSU_LOGIN"] = login
         if password is not None:
             env["KITSU_PWD"] = password
-        
+
         return env
 
     def _get_dialog(self):

--- a/client/ayon_kitsu/addon.py
+++ b/client/ayon_kitsu/addon.py
@@ -55,11 +55,7 @@ class KitsuAddon(AYONAddon, IPluginPaths, ITrayAction):
         )
 
         login, password = load_credentials()
-        if login is None or password is None:
-            self.show_dialog()
-            return
-
-        if validate_credentials(login, password):
+        if login and password and validate_credentials(login, password):
             set_credentials_envs(login, password)
         else:
             self.show_dialog()

--- a/client/ayon_kitsu/addon.py
+++ b/client/ayon_kitsu/addon.py
@@ -68,7 +68,19 @@ class KitsuAddon(AYONAddon, IPluginPaths, ITrayAction):
 
     def get_global_environments(self):
         """Kitsu's global environments."""
-        return {"KITSU_SERVER": self.server_url}
+        env = {"KITSU_SERVER": self.server_url}
+        
+        # Load Kitsu credentials from secure registry and add to environment
+        # This ensures CLI launches (like ayon-launch-scripts) have access to credentials
+        from .credentials import load_credentials
+        
+        login, password = load_credentials()
+        if login is not None:
+            env["KITSU_LOGIN"] = login
+        if password is not None:
+            env["KITSU_PWD"] = password
+        
+        return env
 
     def _get_dialog(self):
         if self._dialog is None:


### PR DESCRIPTION
## Changelog Description
Kitsu credentials are set as global env vars to be able to run in CLI.

## Testing notes:
Run and you'll see `KITSU_LOGIN` and `KITSU_PWD` env vars displayed:
```py
# Test Kitsu addon get_global_environments() implementation
from ayon_core.addon import AddonsManager

# Get the Kitsu addon
manager = AddonsManager()
kitsu_addon = manager.get("kitsu")

if kitsu_addon:
    print("Kitsu addon found!")
    print(f"Server URL: {kitsu_addon.server_url}")
    
    # Test the get_global_environments method
    env = kitsu_addon.get_global_environments()
    print("\nEnvironment variables from get_global_environments():")
    for key, value in env.items():
        # Mask password for security
        if key == "KITSU_PWD" and value:
            print(f"  {key}: {'*' * len(value)} (masked)")
        else:
            print(f"  {key}: {value}")
else:
    print("Kitsu addon not found!")
```
