### PR TITLE
Chore: Use product base types

### DIFF
--- a/client/ayon_kitsu/plugins/publish/collect_kitsu_family.py
+++ b/client/ayon_kitsu/plugins/publish/collect_kitsu_family.py
@@ -36,12 +36,14 @@ class CollectKitsuFamily(plugin.KitsuPublishInstancePlugin):
             return
 
         host_name = instance.context.data["hostName"]
-        product_type = instance.data["productType"]
+        product_base_type = instance.data.get("productBaseType")
+        if not product_base_type:
+            product_base_type = instance.data["productType"]
         task_name = instance.data.get("task")
 
         filtering_criteria = {
             "host_names": host_name,
-            "product_types": product_type,
+            "product_base_types": product_base_type,
             "task_names": task_name
         }
         profile = filter_profiles(
@@ -57,7 +59,7 @@ class CollectKitsuFamily(plugin.KitsuPublishInstancePlugin):
             add_kitsu_family = profile["add_kitsu_family"]
             additional_filters = profile.get("advanced_filtering")
             if additional_filters:
-                families_set = set(families) | {product_type}
+                families_set = set(families) | {product_base_type}
                 self.log.info(
                     "'{}' families used for additional filtering".format(
                         families_set))
@@ -74,7 +76,7 @@ class CollectKitsuFamily(plugin.KitsuPublishInstancePlugin):
                 families.append("kitsu")
 
         self.log.debug("{} 'kitsu' family for instance with '{}'".format(
-            result_str, product_type
+            result_str, product_base_type
         ))
 
     def _get_add_kitsu_f_from_addit_filters(

--- a/client/ayon_kitsu/plugins/publish/integrate_kitsu_note.py
+++ b/client/ayon_kitsu/plugins/publish/integrate_kitsu_note.py
@@ -52,16 +52,6 @@ class IntegrateKitsuNote(KitsuPublishContextPlugin):
         return re.sub(pattern, replace_missing_key, template)
 
     def process(self, context):
-        # Backwards compatibility for wront key
-        if "product_type_requirements" in self.status_change_conditions:
-            family_requirements = self.status_change_conditions[
-                "product_type_requirements"
-            ]
-        else:
-            family_requirements = self.status_change_conditions[
-                "family_requirements"
-            ]
-
         for instance in context:
             # Check if instance is a review by checking its family
             # Allow a match to primary family or any of families
@@ -101,7 +91,9 @@ class IntegrateKitsuNote(KitsuPublishContextPlugin):
 
                 # Check if any family requirement is met
 
-                for family_requirement in family_requirements:
+                for family_requirement in (
+                    self.status_change_conditions["family_requirements"]
+                ):
                     condition = family_requirement["condition"] == "equal"
 
                     for family in families:

--- a/server/__init__.py
+++ b/server/__init__.py
@@ -1,4 +1,4 @@
-from typing import Type
+from typing import Type, Any
 
 from nxtools import logging
 
@@ -17,7 +17,11 @@ from .kitsu.push import (
     push_entities,
     remove_entities,
 )
-from .settings import DEFAULT_VALUES, KitsuSettings
+from .settings import (
+    KitsuSettings,
+    DEFAULT_VALUES,
+    convert_settings_overrides,
+)
 
 #
 # Events:
@@ -134,3 +138,13 @@ class KitsuAddon(BaseServerAddon):
             raise InvalidSettingsException("Kitsu password secret is not set")
 
         self.kitsu = Kitsu(settings.server, actual_email, actual_password)
+
+    async def convert_settings_overrides(
+        self,
+        source_version: str,
+        overrides: dict[str, Any],
+    ) -> dict[str, Any]:
+        await convert_settings_overrides(source_version, overrides)
+        return await super().convert_settings_overrides(
+            source_version, overrides
+        )

--- a/server/settings/__init__.py
+++ b/server/settings/__init__.py
@@ -4,6 +4,5 @@ from .conversions import convert_settings_overrides
 __all__ = (
     "DEFAULT_VALUES",
     "KitsuSettings",
-
     "convert_settings_overrides",
 )

--- a/server/settings/__init__.py
+++ b/server/settings/__init__.py
@@ -1,7 +1,9 @@
 from .main import KitsuSettings, DEFAULT_VALUES
-
+from .conversions import convert_settings_overrides
 
 __all__ = (
     "DEFAULT_VALUES",
     "KitsuSettings",
+
+    "convert_settings_overrides",
 )

--- a/server/settings/conversions.py
+++ b/server/settings/conversions.py
@@ -1,0 +1,26 @@
+from typing import Any
+
+
+def _convert_product_base_types(overrides: dict[str, Any]) -> None:
+    profiles = (
+        overrides
+        .get("publish", {})
+        .get("CollectKitsuFamily", {})
+        .get("profiles")
+    )
+    if not profiles:
+        return
+
+    for profile in profiles:
+        if "product_base_types" in profile or "product_types" not in profile:
+            return
+
+        profile["product_base_types"] = profile.pop("product_types")
+
+
+async def convert_settings_overrides(
+    source_version: str,
+    overrides: dict[str, Any],
+) -> dict[str, Any]:
+    _convert_product_base_types(overrides)
+    return overrides

--- a/server/settings/publish_plugins.py
+++ b/server/settings/publish_plugins.py
@@ -19,7 +19,7 @@ class CollectFamilyProfile(BaseSettingsModel):
         default_factory=list,
         title="Host names",
     )
-    product_types: list[str] = SettingsField(
+    product_base_types: list[str] = SettingsField(
         default_factory=list,
         title="Families",
     )
@@ -124,7 +124,7 @@ PUBLISH_DEFAULT_VALUES = {
                 "host_names": [
                     "traypublisher"
                 ],
-                "product_types": [],
+                "product_base_types": [],
                 "task_types": [],
                 "task_names": [],
                 "add_ftrack_family": True,
@@ -134,7 +134,7 @@ PUBLISH_DEFAULT_VALUES = {
                 "host_names": [
                     "traypublisher"
                 ],
-                "product_types": [
+                "product_base_types": [
                     "matchmove",
                     "shot"
                 ],
@@ -147,7 +147,7 @@ PUBLISH_DEFAULT_VALUES = {
                 "host_names": [
                     "traypublisher"
                 ],
-                "product_types": [
+                "product_base_types": [
                     "plate",
                     "review",
                     "audio"
@@ -169,7 +169,7 @@ PUBLISH_DEFAULT_VALUES = {
                 "host_names": [
                     "maya"
                 ],
-                "product_types": [
+                "product_base_types": [
                     "model",
                     "setdress",
                     "animation",
@@ -186,7 +186,7 @@ PUBLISH_DEFAULT_VALUES = {
                 "host_names": [
                     "tvpaint"
                 ],
-                "product_types": [
+                "product_base_types": [
                     "renderPass"
                 ],
                 "task_types": [],
@@ -198,7 +198,7 @@ PUBLISH_DEFAULT_VALUES = {
                 "host_names": [
                     "tvpaint"
                 ],
-                "product_types": [],
+                "product_base_types": [],
                 "task_types": [],
                 "task_names": [],
                 "add_kitsu_family": True,
@@ -208,7 +208,7 @@ PUBLISH_DEFAULT_VALUES = {
                 "host_names": [
                     "nuke"
                 ],
-                "product_types": [
+                "product_base_types": [
                     "write",
                     "render",
                     "prerender"
@@ -229,7 +229,7 @@ PUBLISH_DEFAULT_VALUES = {
                 "host_names": [
                     "aftereffects"
                 ],
-                "product_types": [
+                "product_base_types": [
                     "render",
                     "workfile"
                 ],
@@ -242,7 +242,7 @@ PUBLISH_DEFAULT_VALUES = {
                 "host_names": [
                     "flame"
                 ],
-                "product_types": [
+                "product_base_types": [
                     "plate",
                     "take"
                 ],
@@ -255,7 +255,7 @@ PUBLISH_DEFAULT_VALUES = {
                 "host_names": [
                     "houdini"
                 ],
-                "product_types": [
+                "product_base_types": [
                     "usd"
                 ],
                 "task_types": [],
@@ -267,7 +267,7 @@ PUBLISH_DEFAULT_VALUES = {
                 "host_names": [
                     "photoshop"
                 ],
-                "product_types": [
+                "product_base_types": [
                     "review"
                 ],
                 "task_types": [],


### PR DESCRIPTION
## Changelog Description
Use product base type in publishing.

## Additional review information
Collect kitsu family now has product base type in filtering instead of product types.

Also removed unnecessary backwards compatibility.

## Testing notes:
1. Kitsu family is collected correctly.
