### PR TITLE
Fix: Restore show in Kitsu Launcher action (revised)

### DIFF
--- a/client/ayon_kitsu/addon.py
+++ b/client/ayon_kitsu/addon.py
@@ -91,13 +91,8 @@ class KitsuAddon(AYONAddon, IPluginPaths, ITrayAction):
         """Implementation of abstract method for `ITrayAction`."""
         self.show_dialog()
 
-    def get_plugin_paths(self):
-        """Implementation of abstract method for `IPluginPaths`."""
-
-        return {
-            "publish": self.get_publish_plugin_paths(),
-            "actions": [os.path.join(KITSU_ROOT, "plugins", "launcher")],
-        }
+    def get_launcher_action_paths(self):
+        return [os.path.join(KITSU_ROOT, "plugins", "launcher")]
 
     def get_publish_plugin_paths(self, host_name=None):
         return [os.path.join(KITSU_ROOT, "plugins", "publish")]

--- a/client/ayon_kitsu/addon.py
+++ b/client/ayon_kitsu/addon.py
@@ -1,6 +1,6 @@
 """Kitsu addon."""
 
-import os
+from pathlib import Path
 
 from ayon_core.addon import (
     AYONAddon,
@@ -9,7 +9,7 @@ from ayon_core.addon import (
 )
 from .version import __version__
 
-KITSU_ROOT = os.path.dirname(os.path.abspath(__file__))
+KITSU_ROOT = Path(__file__).parent
 
 
 class KitsuAddon(AYONAddon, IPluginPaths, ITrayAction):
@@ -92,10 +92,10 @@ class KitsuAddon(AYONAddon, IPluginPaths, ITrayAction):
         self.show_dialog()
 
     def get_launcher_action_paths(self):
-        return [os.path.join(KITSU_ROOT, "plugins", "launcher")]
+        return [KITSU_ROOT.joinpath("plugins", "launcher").as_posix()]
 
     def get_publish_plugin_paths(self, host_name=None):
-        return [os.path.join(KITSU_ROOT, "plugins", "publish")]
+        return [KITSU_ROOT.joinpath("plugins", "publish").as_posix()]
 
 
 def is_kitsu_enabled_in_settings(project_settings):

--- a/client/ayon_kitsu/addon.py
+++ b/client/ayon_kitsu/addon.py
@@ -96,8 +96,7 @@ class KitsuAddon(AYONAddon, IPluginPaths, ITrayAction):
 
         return {
             "publish": self.get_publish_plugin_paths(),
-            # The laucher action is not working since AYON conversion
-            # "actions": [os.path.join(KITSU_ROOT, "plugins", "launcher")],
+            "actions": [os.path.join(KITSU_ROOT, "plugins", "launcher")],
         }
 
     def get_publish_plugin_paths(self, host_name=None):

--- a/client/ayon_kitsu/plugins/launcher/launcher_show_in_kitsu.py
+++ b/client/ayon_kitsu/plugins/launcher/launcher_show_in_kitsu.py
@@ -1,3 +1,4 @@
+from pathlib import Path
 import webbrowser
 import ayon_api
 import gazu
@@ -27,27 +28,11 @@ class ShowInKitsu(LauncherAction):
         if not project:
             raise RuntimeError(f"Project {project_name} not found.")
 
-        project_zou_id = project["data"].get("kitsuProjectId")
-        if not project_zou_id:
-            raise RuntimeError(
-                f"Project {project_name} has no connected kitsu id."
-            )
-
-        folder_kitsu_id = None
-        task_kitsu_id = None
-        if selection.is_folder_selected:
-            folder_entity = selection.folder_entity
-            folder_kitsu_id = folder_entity["data"].get("kitsuId")
-
-            if selection.is_task_selected:
-                task_entity = selection.task_entity
-                task_kitsu_id = task_entity["data"].get("kitsuId")
-
         # Define URL
         url = self.get_url(
-            project_zou_id,
-            folder_kitsu_id,
-            task_kitsu_id,
+            project,
+            selection.folder_entity if selection.is_folder_selected else None,
+            selection.task_entity if selection.is_task_selected else None,
         )
 
         # Open URL in webbrowser
@@ -60,47 +45,88 @@ class ShowInKitsu(LauncherAction):
 
     def get_url(
         self,
-        project_kitsu_id,
-        folder_kitsu_id=None,
-        task_id=None,
+        project,
+        folder=None,
+        task=None,
     ):
-        kitsu_addon = self.get_kitsu_addon()
+        if not (project_kitsu_id := project["data"].get("kitsuProjectId")):
+            raise RuntimeError(
+                f"Project {project['name']} has no connected kitsu id."
+            )
 
-        # Get kitsu url without /api
-        kitsu_url = kitsu_addon.server_url
-        if kitsu_url.endswith("/api"):
-            kitsu_url = kitsu_url[:-4]
-
-        url = f"{kitsu_url}/productions/{project_kitsu_id}"
-
-        # Handle task first if available
-        if task_id:
-            # Go to task page
-            task = gazu.task.get_task(task_id)
-            if task:
-                return f"{url}/{task['type']}s/tasks/{task_id}"
-
-        # Handle folder entities
-        if folder_kitsu_id:
-            # Short IDs are typically for home page (assets, shots, etc.)
-            if len(folder_kitsu_id) < 30:
-                return f"{url}/{folder_kitsu_id}s"
-
-            # Try to get the entity to determine its type
-            try:
-                entity = gazu.entity.get_entity(folder_kitsu_id)
-            except gazu.exception.RouteNotFoundException:
-                entity = None
-
-            if entity:
-                entity_type = entity.get("type", "").lower()
-                if entity_type:
-                    return f"{url}/{entity_type}s/{folder_kitsu_id}"
+        if task:
+            return gazu.task.get_task_url(
+                {"project_id": project_kitsu_id, "id": task.get("kitsuId")}
+            )
+        elif folder:
+            project_url = Path(
+                gazu.project.get_project_url({"id": project_kitsu_id})
+            )
+            folder_type = folder["folderType"]
+            folder_path = Path(folder["path"])
+            kitsu_id = folder["data"].get("kitsuId")
+            if folder_type == "Folder":
+                if len(folder_path.parents) == 1:  # Root folder
+                    return f"{project_url.parent}/{folder['name']}"
+                elif len(folder_path.parents) == 2:  # Asset type
+                    return self._get_asset_type_url(
+                        project_kitsu_id, folder["label"]
+                    )
+                else:  # Asset
+                    return gazu.asset.get_asset_url(
+                        {"project_id": project_kitsu_id, "id": kitsu_id}
+                    )
+            elif folder_type == "Sequence":
+                return self._get_sequence_url(
+                    project, project_kitsu_id, kitsu_id, folder_path
+                )
+            elif folder_type == "Episode":
+                return gazu.shot.get_episode_url(
+                    {"project_id": project_kitsu_id, "id": kitsu_id}
+                )
+            elif folder_type == "Shot":
+                return gazu.shot.get_shot_url(
+                    {"project_id": project_kitsu_id, "id": kitsu_id}
+                )
             else:
-                pass
-                # If not an entity, we assume it is a asset subtype e.g Props
-                # So open the assets page
-                return f"{url}/assets"
+                return (
+                    f"{project_url.parent}/{folder_type.lower()}s/{kitsu_id}"
+                )
 
-        # Default to project shots page
-        return f"{url}/shots"
+    def _get_asset_type_url(self, project_kitsu_id, folder_label):
+        """Get the URL for the asset type page.
+
+        Meant to be replaced by gazu.asset.get_asset_type_url when available.
+        See https://github.com/cgwire/gazu/issues/392
+        """
+        project_url = Path(
+            gazu.project.get_project_url({"id": project_kitsu_id})
+        )
+        return f"{project_url.parent}/episodes/all/assets?search=+type=[{folder_label}]"
+
+    def _get_sequence_url(
+        self, project, project_kitsu_id, kitsu_id, folder_path
+    ):
+        """Get the URL for the sequence page.
+
+        Meant to be replaced by gazu.shot.get_sequence_url when available.
+        See https://github.com/cgwire/gazu/issues/392
+        """
+        if folder_path.parts[1] == "episodes":
+            episode_folder = ayon_api.get_folder_by_path(
+                project["name"], folder_path.parents[0].as_posix()
+            )
+            episode_url = Path(
+                gazu.shot.get_episode_url(
+                    {
+                        "project_id": project_kitsu_id,
+                        "id": episode_folder["data"].get("kitsuId"),
+                    }
+                )
+            )
+            return f"{episode_url.parent}/sequences/{kitsu_id}"
+        else:
+            project_url = Path(
+                gazu.project.get_project_url({"id": project_kitsu_id})
+            )
+            return f"{project_url.parent}/sequences/{kitsu_id}"

--- a/client/ayon_kitsu/plugins/launcher/launcher_show_in_kitsu.py
+++ b/client/ayon_kitsu/plugins/launcher/launcher_show_in_kitsu.py
@@ -45,23 +45,33 @@ class ShowInKitsu(LauncherAction):
 
     def get_url(
         self,
-        project,
-        folder=None,
-        task=None,
-    ):
+        project: dict,
+        folder: dict = None,
+        task: dict = None,
+    ) -> str:
+        """Get the URL for the project, folder, or task.
+
+        Args:
+            project (dict): The project data.
+            folder (dict): The folder data.
+            task (dict): The task data.
+
+        Returns:
+            str: The URL for the project, folder, or task.
+        """
         if not (project_kitsu_id := project["data"].get("kitsuProjectId")):
             raise RuntimeError(
                 f"Project {project['name']} has no connected kitsu id."
             )
+        project_url = Path(
+            gazu.project.get_project_url({"id": project_kitsu_id})
+        )
 
         if task:
             return gazu.task.get_task_url(
                 {"project_id": project_kitsu_id, "id": task.get("kitsuId")}
             )
         elif folder:
-            project_url = Path(
-                gazu.project.get_project_url({"id": project_kitsu_id})
-            )
             folder_type = folder["folderType"]
             folder_path = Path(folder["path"])
             kitsu_id = folder["data"].get("kitsuId")
@@ -92,6 +102,8 @@ class ShowInKitsu(LauncherAction):
                 return (
                     f"{project_url.parent}/{folder_type.lower()}s/{kitsu_id}"
                 )
+        else:
+            return project_url
 
     def _get_asset_type_url(self, project_kitsu_id, folder_label):
         """Get the URL for the asset type page.

--- a/client/ayon_kitsu/plugins/launcher/launcher_show_in_kitsu.py
+++ b/client/ayon_kitsu/plugins/launcher/launcher_show_in_kitsu.py
@@ -102,7 +102,10 @@ class ShowInKitsu(LauncherAction):
         project_url = Path(
             gazu.project.get_project_url({"id": project_kitsu_id})
         )
-        return f"{project_url.parent}/episodes/all/assets?search=+type=[{folder_label}]"
+        return (
+            f"{project_url.parent}/episodes/all/assets",
+            f"?search=+type=[{folder_label}]",
+        )
 
     def _get_sequence_url(
         self, project, project_kitsu_id, kitsu_id, folder_path

--- a/client/ayon_kitsu/plugins/launcher/launcher_show_in_kitsu.py
+++ b/client/ayon_kitsu/plugins/launcher/launcher_show_in_kitsu.py
@@ -126,8 +126,8 @@ class ShowInKitsu(LauncherAction):
             gazu.project.get_project_url({"id": project_kitsu_id})
         )
         return (
-            f"{project_url.parent}/episodes/all/assets",
-            f"?search=+type=[{folder_label}]",
+            f"{project_url.parent}/episodes/all/assets"
+            f"?search=+type=[{folder_label}]"
         )
 
     def _get_sequence_url(

--- a/client/ayon_kitsu/plugins/launcher/launcher_show_in_kitsu.py
+++ b/client/ayon_kitsu/plugins/launcher/launcher_show_in_kitsu.py
@@ -1,5 +1,6 @@
 import webbrowser
 import ayon_api
+import gazu
 
 from ayon_core.pipeline import LauncherAction
 from ayon_core.addon import AddonsManager
@@ -26,19 +27,17 @@ class ShowInKitsu(LauncherAction):
         if not project:
             raise RuntimeError(f"Project {project_name} not found.")
 
-        project_zou_id = project["data"].get("zou_id")
+        project_zou_id = project["data"].get("kitsuProjectId")
         if not project_zou_id:
             raise RuntimeError(
                 f"Project {project_name} has no connected kitsu id."
             )
 
         folder_kitsu_id = None
-        folder_type = None
         task_kitsu_id = None
         if selection.is_folder_selected:
             folder_entity = selection.folder_entity
             folder_kitsu_id = folder_entity["data"].get("kitsuId")
-            folder_type = folder_entity["folderType"]
 
             if selection.is_task_selected:
                 task_entity = selection.task_entity
@@ -48,7 +47,6 @@ class ShowInKitsu(LauncherAction):
         url = self.get_url(
             project_zou_id,
             folder_kitsu_id,
-            folder_type,
             task_kitsu_id,
         )
 
@@ -64,27 +62,45 @@ class ShowInKitsu(LauncherAction):
         self,
         project_kitsu_id,
         folder_kitsu_id=None,
-        folder_type=None,
         task_id=None,
     ):
-        shots_url = {"Shots", "Sequence", "Shot"}
         kitsu_addon = self.get_kitsu_addon()
 
-        # Get kitsu url with /api stripped
-        kitsu_url = kitsu_addon.server_url.rstrip("/api")
+        # Get kitsu url without /api
+        kitsu_url = kitsu_addon.server_url
+        if kitsu_url.endswith("/api"):
+            kitsu_url = kitsu_url[:-4]
 
-        sub_url = f"/productions/{project_kitsu_id}"
-        kitsu_type = "shots" if folder_type in shots_url else "assets"
+        url = f"{kitsu_url}/productions/{project_kitsu_id}"
 
+        # Handle task first if available
         if task_id:
             # Go to task page
-            # /productions/{project-id}/{asset_type}/tasks/{task_id}
-            sub_url += f"/{kitsu_type}/tasks/{task_id}"
+            task = gazu.task.get_task(task_id)
+            if task:
+                return f"{url}/{task['type']}s/tasks/{task_id}"
 
-        elif folder_kitsu_id:
-            # Go to asset or shot page
-            # /productions/{project-id}/assets/{entity_id}
-            # /productions/{project-id}/shots/{entity_id}
-            sub_url += f"/{kitsu_type}/{folder_kitsu_id}"
+        # Handle folder entities
+        if folder_kitsu_id:
+            # Short IDs are typically for home page (assets, shots, etc.)
+            if len(folder_kitsu_id) < 30:
+                return f"{url}/{folder_kitsu_id}s"
 
-        return f"{kitsu_url}{sub_url}"
+            # Try to get the entity to determine its type
+            try:
+                entity = gazu.entity.get_entity(folder_kitsu_id)
+            except gazu.exception.RouteNotFoundException:
+                entity = None
+
+            if entity:
+                entity_type = entity.get("type", "").lower()
+                if entity_type:
+                    return f"{url}/{entity_type}s/{folder_kitsu_id}"
+            else:
+                pass
+                # If not an entity, we assume it is a asset subtype e.g Props
+                # So open the assets page
+                return f"{url}/assets"
+
+        # Default to project shots page
+        return f"{url}/shots"

--- a/client/ayon_kitsu/plugins/launcher/launcher_show_in_kitsu.py
+++ b/client/ayon_kitsu/plugins/launcher/launcher_show_in_kitsu.py
@@ -105,7 +105,7 @@ class ShowInKitsu(LauncherAction):
         else:
             return project_url.as_posix()
 
-    def _get_asset_type_url(self, project_kitsu_id, folder_label):
+    def _get_asset_type_url(self, project_kitsu_id: str, folder_label: str) -> str:
         """Get the URL for the asset type page.
 
         Meant to be replaced by gazu.asset.get_asset_type_url when available.
@@ -120,8 +120,8 @@ class ShowInKitsu(LauncherAction):
         )
 
     def _get_sequence_url(
-        self, project, project_kitsu_id, kitsu_id, folder_path
-    ):
+        self, project: dict, project_kitsu_id: str, kitsu_id: str, folder_path: Path
+    ) -> str:
         """Get the URL for the sequence page.
 
         Meant to be replaced by gazu.shot.get_sequence_url when available.

--- a/client/ayon_kitsu/plugins/launcher/launcher_show_in_kitsu.py
+++ b/client/ayon_kitsu/plugins/launcher/launcher_show_in_kitsu.py
@@ -68,13 +68,22 @@ class ShowInKitsu(LauncherAction):
         )
 
         if task:
+            if not (task_id := task.get("kitsuId")):
+                raise RuntimeError(
+                    f"Task {task['name']} has no connected kitsu entity."
+                )
+
             return gazu.task.get_task_url(
-                {"project_id": project_kitsu_id, "id": task.get("kitsuId")}
+                {"project_id": project_kitsu_id, "id": task_id}
             )
         elif folder:
             folder_type = folder["folderType"]
             folder_path = Path(folder["path"])
-            kitsu_id = folder["data"].get("kitsuId")
+            if not (kitsu_id := folder["data"].get("kitsuId")):
+                raise RuntimeError(
+                    f"Folder {folder['name']} has no connected kitsu entity."
+                )
+
             if folder_type == "Folder":
                 if len(folder_path.parents) == 1:  # Root folder
                     return f"{project_url.parent}/{folder['name']}"

--- a/client/ayon_kitsu/plugins/launcher/launcher_show_in_kitsu.py
+++ b/client/ayon_kitsu/plugins/launcher/launcher_show_in_kitsu.py
@@ -103,7 +103,7 @@ class ShowInKitsu(LauncherAction):
                     f"{project_url.parent}/{folder_type.lower()}s/{kitsu_id}"
                 )
         else:
-            return project_url
+            return project_url.as_posix()
 
     def _get_asset_type_url(self, project_kitsu_id, folder_label):
         """Get the URL for the asset type page.

--- a/client/ayon_kitsu/plugins/launcher/launcher_show_in_kitsu.py
+++ b/client/ayon_kitsu/plugins/launcher/launcher_show_in_kitsu.py
@@ -105,7 +105,9 @@ class ShowInKitsu(LauncherAction):
         else:
             return project_url.as_posix()
 
-    def _get_asset_type_url(self, project_kitsu_id: str, folder_label: str) -> str:
+    def _get_asset_type_url(
+        self, project_kitsu_id: str, folder_label: str
+    ) -> str:
         """Get the URL for the asset type page.
 
         Meant to be replaced by gazu.asset.get_asset_type_url when available.
@@ -120,7 +122,11 @@ class ShowInKitsu(LauncherAction):
         )
 
     def _get_sequence_url(
-        self, project: dict, project_kitsu_id: str, kitsu_id: str, folder_path: Path
+        self,
+        project: dict,
+        project_kitsu_id: str,
+        kitsu_id: str,
+        folder_path: Path,
     ) -> str:
         """Get the URL for the sequence page.
 


### PR DESCRIPTION
## Changelog Description
Restore "Show in Kitsu" launcher action for tasks, folders, and projects

## Additional review information

> The "Show in Kitsu" action was disabled. Updated code to work with latest server, and changed logic for getting URL to work with more Kitsu entity types (Edit, Sequence, shot etc.)
> 
> This uses Gazu to get task url, instead of creating this ourselves. Also using Gazu to get the type of the folder, when folders are selected. The type returned is always singular, while the URL we need is plural, eg. it returns "asset" while the URL should be "assets", so we need to add an "s" there. A bit weird, but it works.
> 
> When selecting a Project, or when something something goes wrong, we open the "Shots" page, as Kitsu does not have a home page for projects. Preferably this would respect the "Homepage" setting in Kitsu, or a similar one in Ayon settings, but was out of scope for now.

Refactor proposal in order to rely as much as possible on gazu API URL getters.
Also handles better sequences in a TV show context.

Created private methods until missing url getters are added: https://github.com/cgwire/gazu/issues/392

Related to https://github.com/ynput/ayon-kitsu/pull/108

## Testing notes:
1. Open launcher.
2. Select one of: project, folder, subfolder, task
3. Press "Show in Kitsu"
