### PR TITLE
Remove instance version number given as argument to add_preview and let Kitsu determine revision number

### DIFF
--- a/client/ayon_kitsu/plugins/publish/integrate_kitsu_review.py
+++ b/client/ayon_kitsu/plugins/publish/integrate_kitsu_review.py
@@ -45,6 +45,5 @@ class IntegrateKitsuReview(KitsuPublishInstancePlugin):
                 comment=comment_id,
                 preview_file_path=review_path,
                 normalize_movie=True,
-                revision=instance.data["version"],
             )
             self.log.info("Review upload on comment")

--- a/client/ayon_kitsu/plugins/publish/integrate_kitsu_review.py
+++ b/client/ayon_kitsu/plugins/publish/integrate_kitsu_review.py
@@ -13,6 +13,8 @@ class IntegrateKitsuReview(KitsuPublishInstancePlugin):
     families = ["kitsu"]
     optional = True
 
+    match_version_number = True
+
     def process(self, instance):
         # Check comment has been created
         comment_id = instance.data.get("kitsuComment", {}).get("id")

--- a/client/ayon_kitsu/plugins/publish/integrate_kitsu_review.py
+++ b/client/ayon_kitsu/plugins/publish/integrate_kitsu_review.py
@@ -45,5 +45,10 @@ class IntegrateKitsuReview(KitsuPublishInstancePlugin):
                 comment=comment_id,
                 preview_file_path=review_path,
                 normalize_movie=True,
+                revision=(
+                    instance.data["version"]
+                    if self.match_version_number
+                    else None
+                ),
             )
             self.log.info("Review upload on comment")

--- a/server/settings/publish_plugins.py
+++ b/server/settings/publish_plugins.py
@@ -107,9 +107,12 @@ class IntegrateKitsuNotes(BaseSettingsModel):
 class IntegrateKitsuReviews(BaseSettingsModel):
     match_version_number: bool = SettingsField(
         title="Match version number",
-        description="If enabled refrain from publishing reviewables directly" \
-        " into Kitsu without passing through AYON, as this can desynchronize" \
-        " product version and revision number and cause errors during publish."
+        description=(
+            "Set Kitsu note revision to match AYON version number.\n\n"
+            "Note: If enabled avoid uploading reviewables directly"
+            " into Kitsu without passing through AYON, as this can desynchronize"
+            " product version and revision number and cause errors during publish."
+        )
     )
 
 class PublishPlugins(BaseSettingsModel):

--- a/server/settings/publish_plugins.py
+++ b/server/settings/publish_plugins.py
@@ -104,6 +104,13 @@ class IntegrateKitsuNotes(BaseSettingsModel):
         title="Custom Comment Template",
     )
 
+class IntegrateKitsuReviews(BaseSettingsModel):
+    match_version_number: bool = SettingsField(
+        title="Match version number",
+        description="If enabled refrain from publishing reviewables directly" \
+        " into Kitsu without passing through AYON, as this can desynchronize" \
+        " product version and revision number and cause errors during publish."
+    )
 
 class PublishPlugins(BaseSettingsModel):
     CollectKitsuFamily: CollectKitsuFamilyPluginModel = SettingsField(
@@ -113,6 +120,10 @@ class PublishPlugins(BaseSettingsModel):
     IntegrateKitsuNote: IntegrateKitsuNotes = SettingsField(
         default_factory=IntegrateKitsuNotes,
         title="Integrate Kitsu Note"
+    )
+    IntegrateKitsuReview: IntegrateKitsuReviews = SettingsField(
+        default_factory=IntegrateKitsuReviews,
+        title="Integrate Kitsu Review"
     )
 
 
@@ -294,5 +305,8 @@ PUBLISH_DEFAULT_VALUES = {
 | family | `{family}` |
 | name | `{name}` |""",
         },
-    }
+    },
+    "IntegrateKitsuReview": {
+        "match_version_number": True,
+    },
 }


### PR DESCRIPTION
## Changelog Description
Remove instance version number given as argument to `add_preview` and let Kitsu determine revision number, resolves #127

## Additional Info
This PR aims to solve #127 by simply not providing the `"version"` as revision number to `add_preview` and letting Kitsu assign this number itself.

If `instance.data["version"]` was passed as an argument it was for Ayon and Kitsu to more accurately reflect each other, however several different kinds of products can create reviewables for a same task in Kitsu, and a product or instance's version number may not be an accurate basis for the latest revision preview number. Also, as described in the issue, you can add revision previews directly through Kitsu and Ayon being unaware of it.
When no `revision` argument is given, Kitsu will automatically give it the right n+1 version number and will avoid conflicts, this is what was done here.

For these reasons it seems this is not that important to keep the revision number absolutely synchronized to a product's version and removing this argument can also prevent some issues.

## Testing notes:
You can follow the steps described in #127 to see the change in behavior.
