### PR TITLE
Feature: Normalize movie setting

### DIFF
--- a/client/ayon_kitsu/plugins/publish/integrate_kitsu_review.py
+++ b/client/ayon_kitsu/plugins/publish/integrate_kitsu_review.py
@@ -13,6 +13,7 @@ class IntegrateKitsuReview(KitsuPublishInstancePlugin):
     families = ["kitsu"]
     optional = True
 
+    normalize_movie = True
     match_version_number = True
 
     def process(self, instance):
@@ -46,7 +47,7 @@ class IntegrateKitsuReview(KitsuPublishInstancePlugin):
                 task=task_id,
                 comment=comment_id,
                 preview_file_path=review_path,
-                normalize_movie=True,
+                normalize_movie=self.normalize_movie,
                 revision=(
                     instance.data["version"]
                     if self.match_version_number

--- a/server/settings/publish_plugins.py
+++ b/server/settings/publish_plugins.py
@@ -105,6 +105,13 @@ class IntegrateKitsuNotes(BaseSettingsModel):
     )
 
 class IntegrateKitsuReviews(BaseSettingsModel):
+    normalize_movie: bool = SettingsField(
+        title="Normalize movie",
+        description=(
+            "When enabled, Kitsu will transcode uploaded movie previews"
+            " for web playback."
+        ),
+    )
     match_version_number: bool = SettingsField(
         title="Match version number",
         description=(
@@ -310,6 +317,7 @@ PUBLISH_DEFAULT_VALUES = {
         },
     },
     "IntegrateKitsuReview": {
+        "normalize_movie": True,
         "match_version_number": True,
     },
 }


### PR DESCRIPTION
## Changelog Description
Add plugin setting for `normalize_movie` Gazy config.

## Additional review information
This argument triggers conversion on Kitsu's server when the movie is uploaded. Because the rendered movie file by Ayon is already converted to be playable from a Web UI, it maybe redudant to re-encode it inside Kitsu when we could use the file directly.

## Testing notes:
1. Change the setting
2. Publish any scene with a render instance
