### PR TITLE
Fix: sync user process

### DIFF
--- a/server/__init__.py
+++ b/server/__init__.py
@@ -11,6 +11,7 @@ from ayon_server.secrets import Secrets
 from .kitsu import Kitsu, KitsuMock
 from .kitsu.init_pairing import InitPairingRequest, init_pairing, sync_request
 from .kitsu.pairing_list import PairingItemModel, get_pairing_list
+from .kitsu.user_list import get_user_sync_list
 from .kitsu.push import (
     PushEntitiesRequestModel,
     RemoveEntitiesRequestModel,
@@ -54,6 +55,7 @@ class KitsuAddon(BaseServerAddon):
         self.add_endpoint("/sync/{project_name}", self.sync, method="POST")
         self.add_endpoint("/push", self.push, method="POST")
         self.add_endpoint("/remove", self.remove, method="POST")
+        self.add_endpoint("/users", self.list_users, method="GET")
 
     async def setup(self):
         pass
@@ -101,6 +103,19 @@ class KitsuAddon(BaseServerAddon):
     ) -> list[PairingItemModel]:
         await self.ensure_kitsu(mock)
         return await get_pairing_list(self)
+
+    async def list_users(self) -> list[dict[str, Any]]:
+        users = await get_user_sync_list()
+        return [
+            {
+                "name": user.name,
+                "kitsu_id": user.kitsu_id,
+                "email": user.email,
+                "full_name": user.full_name,
+                "active": user.active,
+            }
+            for user in users
+        ]
 
     async def init_pairing(
         self,

--- a/server/__init__.py
+++ b/server/__init__.py
@@ -104,7 +104,10 @@ class KitsuAddon(BaseServerAddon):
         await self.ensure_kitsu(mock)
         return await get_pairing_list(self)
 
-    async def list_users(self) -> list[dict[str, Any]]:
+    async def list_users(self, user: CurrentUser) -> list[dict[str, Any]]:
+        if not user.is_manager:
+            raise ForbiddenException("Only managers can list AYON users")
+
         users = await get_user_sync_list()
         return [
             {

--- a/server/kitsu/push.py
+++ b/server/kitsu/push.py
@@ -255,6 +255,7 @@ async def sync_person(
 
     payload = {
         "name": username,
+        "active": entity_dict.get("active", True),
         "attrib": {
             "fullName": entity_dict.get("full_name", ""),
             "email": entity_dict.get("email", ""),
@@ -879,13 +880,19 @@ async def remove_entities(
     payload: RemoveEntitiesRequestModel,
 ) -> dict[str, dict[Any, Any]]:
     start_time = time.time()
-    project = await ProjectEntity.load(payload.project_name)
+    project = None
 
     # A mapping of kitsu entity ids to folder ids
     # they are added when a task or folder are deleted and returned
     #   by the method - useful for testing
     folders = {}
     tasks = {}
+
+    async def get_project() -> "ProjectEntity":
+        nonlocal project
+        if project is None:
+            project = await ProjectEntity.load(payload.project_name)
+        return project
 
     settings = await addon.get_studio_settings()
     for entity_dict in payload.entities:
@@ -900,7 +907,7 @@ async def remove_entities(
                 await update_project(
                     addon,
                     user,
-                    project,
+                    await get_project(),
                     entity_dict,
                 )
         elif entity_dict["type"] == "Person":
@@ -911,8 +918,9 @@ async def remove_entities(
             await target_user.delete()
 
         elif entity_dict["type"] == "Task":
+            p = await get_project()
             task = await get_task_by_kitsu_id(
-                project.name,
+                p.name,
                 entity_dict["id"],
                 tasks,
             )
@@ -920,7 +928,7 @@ async def remove_entities(
                 continue
 
             await delete_task(
-                project_name=project.name,
+                project_name=p.name,
                 task_id=task.id,
                 user=user,
             )
@@ -928,8 +936,9 @@ async def remove_entities(
             tasks[entity_dict["id"]] = task.id
 
         else:
+            p = await get_project()
             folder = await get_folder_by_kitsu_id(
-                project.name,
+                p.name,
                 entity_dict["id"],
                 folders,
             )
@@ -937,7 +946,7 @@ async def remove_entities(
                 continue
 
             await delete_folder(
-                project_name=project.name,
+                project_name=p.name,
                 folder_id=folder.id,
                 user=user,
             )

--- a/server/kitsu/push.py
+++ b/server/kitsu/push.py
@@ -288,17 +288,6 @@ async def sync_person(
                     json=payload,
                     headers=headers,
                 )
-            # Rename the user
-            # TODO: We should discourage renaming users.
-            # Maybe just change the fullName in the case there's a typo,
-            # but changing username may have weird side effects.
-            payload = {"newName": username}
-            async with httpx.AsyncClient() as client:
-                await client.patch(
-                    f"{ayon_server_url}/api/users/{target_user.name}/rename",
-                    json=payload,
-                    headers=headers,
-                )
         except Exception as e:
             print(e)
     else:  # Create user

--- a/server/kitsu/user_list.py
+++ b/server/kitsu/user_list.py
@@ -3,17 +3,19 @@ from ayon_server.types import Field, OPModel
 
 
 class UserSyncInfoModel(OPModel):
-    """Minimal user data needed by the processor for person change detection."""
+    """Minimal user data needed by the processor for person change matching."""
 
     name: str = Field(..., title="AYON username")
-    kitsu_id: str | None = Field(None, title="Kitsu person ID stored in user data")
+    kitsu_id: str | None = Field(
+        None, title="Kitsu person ID stored in user data"
+    )
     email: str | None = Field(None, title="Email address")
     full_name: str | None = Field(None, title="Full name")
     active: bool = Field(True, title="Whether the user is active in AYON")
 
 
 async def get_user_sync_list() -> list[UserSyncInfoModel]:
-    """Return all AYON users with the fields needed to detect Kitsu person changes.
+    """Return all AYON users with the fields to detect Kitsu person changes.
 
     Queries the database directly so that ``data->>'kitsuId'`` is available,
     which is not exposed by the GraphQL ``UserNode`` schema.  Both active and
@@ -21,8 +23,7 @@ async def get_user_sync_list() -> list[UserSyncInfoModel]:
     mirrored to AYON.
     """
     result: list[UserSyncInfoModel] = []
-    async for row in Postgres.iterate(
-        """
+    async for row in Postgres.iterate("""
         SELECT
             name,
             data->>'kitsuId'          AS kitsu_id,
@@ -30,7 +31,6 @@ async def get_user_sync_list() -> list[UserSyncInfoModel]:
             attrib->>'fullName'       AS full_name,
             active
         FROM public.users
-        """
-    ):
+        """):
         result.append(UserSyncInfoModel(**dict(row)))
     return result

--- a/server/kitsu/user_list.py
+++ b/server/kitsu/user_list.py
@@ -1,0 +1,36 @@
+from ayon_server.lib.postgres import Postgres
+from ayon_server.types import Field, OPModel
+
+
+class UserSyncInfoModel(OPModel):
+    """Minimal user data needed by the processor for person change detection."""
+
+    name: str = Field(..., title="AYON username")
+    kitsu_id: str | None = Field(None, title="Kitsu person ID stored in user data")
+    email: str | None = Field(None, title="Email address")
+    full_name: str | None = Field(None, title="Full name")
+    active: bool = Field(True, title="Whether the user is active in AYON")
+
+
+async def get_user_sync_list() -> list[UserSyncInfoModel]:
+    """Return all AYON users with the fields needed to detect Kitsu person changes.
+
+    Queries the database directly so that ``data->>'kitsuId'`` is available,
+    which is not exposed by the GraphQL ``UserNode`` schema.  Both active and
+    inactive users are returned so that Kitsu deactivations can be detected and
+    mirrored to AYON.
+    """
+    result: list[UserSyncInfoModel] = []
+    async for row in Postgres.iterate(
+        """
+        SELECT
+            name,
+            data->>'kitsuId'          AS kitsu_id,
+            attrib->>'email'          AS email,
+            attrib->>'fullName'       AS full_name,
+            active
+        FROM public.users
+        """
+    ):
+        result.append(UserSyncInfoModel(**dict(row)))
+    return result

--- a/services/processor/processor/fullsync.py
+++ b/services/processor/processor/fullsync.py
@@ -10,6 +10,7 @@ if TYPE_CHECKING:
 
 from .utils import (
     get_asset_types,
+    get_persons,
     get_statuses,
     get_task_types,
     preprocess_asset,
@@ -161,7 +162,7 @@ def project_full_sync(
     asset_types = get_asset_types(kitsu_project_id)
     task_statuses = get_statuses()
     task_types = get_task_types(kitsu_project_id)
-    persons = gazu.person.all_persons()
+    persons = get_persons(parent.entrypoint)
 
     assets = get_assets(kitsu_project_id, asset_types)
     tasks = get_tasks(kitsu_project_id, task_types, task_statuses)

--- a/services/processor/processor/fullsync.py
+++ b/services/processor/processor/fullsync.py
@@ -10,7 +10,7 @@ if TYPE_CHECKING:
 
 from .utils import (
     get_asset_types,
-    get_persons,
+    get_persons_to_update,
     get_statuses,
     get_task_types,
     preprocess_asset,
@@ -162,10 +162,12 @@ def project_full_sync(
     asset_types = get_asset_types(kitsu_project_id)
     task_statuses = get_statuses()
     task_types = get_task_types(kitsu_project_id)
-    persons = get_persons(parent.entrypoint)
+    persons_to_update = get_persons_to_update(parent.entrypoint)
 
     assets = get_assets(kitsu_project_id, asset_types)
-    tasks = get_tasks(kitsu_project_id, task_types, task_statuses)
+    tasks = get_tasks(
+        kitsu_project_id, task_types, task_statuses, gazu.person.all_persons()
+    )
     sync_casting_settings = (
         parent.settings.get("sync_settings", {})
         .get("sync_casting", {})
@@ -185,7 +187,14 @@ def project_full_sync(
         concepts = []
 
     entities = (
-        persons + assets + episodes + seqs + shots + edits + concepts + tasks
+        persons_to_update
+        + assets
+        + episodes
+        + seqs
+        + shots
+        + edits
+        + concepts
+        + tasks
     )
     if casting_enabled:
         entities += get_casting_links(shots, assets)

--- a/services/processor/processor/update_from_kitsu.py
+++ b/services/processor/processor/update_from_kitsu.py
@@ -304,10 +304,19 @@ def delete_concept(parent: "KitsuProcessor", data: dict[str, str]):
 
 
 def create_or_update_person(parent: "KitsuProcessor", data: dict[str, str]):
+    """Push a Kitsu person to AYON when their data has changed."""
     logging.info(f"create_or_update_person: {data}")
     entity = gazu.person.get_person(data["person_id"])
 
-    # Add ayon base url so we can use it in REST calls later on
+    ayon_users = utils.get_ayon_user_sync_info(parent.entrypoint)
+    by_kitsu_id, by_email, by_name = utils.build_ayon_user_lookups(ayon_users)
+    if not utils.person_needs_sync(entity, by_kitsu_id, by_email, by_name):
+        logging.info(
+            f"create_or_update_person: skipping {entity.get('full_name')!r}"
+            f" — AYON already up to date"
+        )
+        return
+
     entity["ayon_server_url"] = ayon_api.get_base_url()
 
     return ayon_api.post(
@@ -319,18 +328,14 @@ def create_or_update_person(parent: "KitsuProcessor", data: dict[str, str]):
 
 def delete_person(parent: "KitsuProcessor", data: dict[str, str]):
     logging.info(f"delete_person: {data}")
-    project_name = parent.get_paired_ayon_project(data["project_id"])
-    if not project_name:
-        return  # do nothing as this kitsu and ayon project are not paired
-
     entity = {
         "id": data["person_id"],
-        "type": "person",
+        "type": "Person",
         "ayon_server_url": ayon_api.get_base_url(),
     }
     return ayon_api.post(
         f"{parent.entrypoint}/remove",
-        project_name=project_name,
+        project_name="",
         entities=[entity],
     )
 

--- a/services/processor/processor/utils.py
+++ b/services/processor/processor/utils.py
@@ -1,4 +1,8 @@
-""" utils shared between fullsync.py and update_from_kitsu.py """
+"""Utils shared between fullsync.py and update_from_kitsu.py."""
+
+import re
+import unicodedata
+from typing import Any
 
 import ayon_api
 import gazu
@@ -73,3 +77,167 @@ def preprocess_task(
     )
 
     return task
+
+
+def _remove_accents(s: str) -> str:
+    """Strip diacritics and normalize special characters for AYON usernames.
+    
+    Args:
+        s: The string to remove accents from.
+
+    Returns:
+        The string with accents removed.
+    """
+    nfkd = unicodedata.normalize("NFKD", s)
+    result = "".join(c for c in nfkd if not unicodedata.combining(c))
+    replacement_map = {
+        "Æ": "AE", "Ð": "D", "Ø": "O", "Þ": "TH",
+        "ß": "ss", "æ": "ae", "ð": "d", "ø": "o", "þ": "th",
+        "Œ": "OE", "œ": "oe", "ƒ": "f",
+    }
+    for k, v in replacement_map.items():
+        result = result.replace(k, v)
+    return re.sub(r"[^a-zA-Z0-9_\.\-]", "", result)
+
+
+def _to_entity_name(name: str) -> str:
+    """Sanitize a string into a valid AYON entity name.
+
+    Args:
+        name: The string to sanitize.
+
+    Returns:
+        The sanitized string.
+    """
+    name = name.strip()
+    name = re.sub(r"\s+", "_", name)
+    name = re.sub(r"[^a-zA-Z0-9_\.\-]", "", name)
+    name = re.sub(r"^[^a-zA-Z0-9_]+", "", name)
+    name = re.sub(r"[^a-zA-Z0-9_]+$", "", name)
+    return name
+
+
+def to_username(first_name: str, last_name: str | None = None) -> str:
+    """Derive an AYON username from Kitsu first and last name.
+
+    Mirrors ``server/kitsu/addon_helpers.to_username``; duplicated here because
+    the processor is deployed separately from the addon server.
+
+    Args:
+        first_name: The first name of the person.
+        last_name: The last name of the person.
+
+    Returns:
+        The derived username.
+    """
+    name = (
+        f"{first_name.strip()}.{last_name.strip()}"
+        if last_name
+        else first_name.strip()
+    )
+    return _to_entity_name(_remove_accents(name.lower()))
+
+
+def get_ayon_user_sync_info(entrypoint: str) -> list[dict[str, Any]]:
+    """Fetch the AYON user list from the addon's /users endpoint.
+
+    Returns one dict per user with keys: ``name``, ``kitsu_id``, ``email``,
+    ``full_name``.  The server queries the DB directly so ``kitsu_id`` is
+    available (the GraphQL ``UserNode`` schema does not expose ``data``).
+
+    Args:
+        entrypoint: Base addon REST path, e.g. ``/addons/kitsu/1.2.7``.
+    """
+    response = ayon_api.get(f"{entrypoint}/users")
+    response.raise_for_status()
+    return response.data
+
+
+def build_ayon_user_lookups(
+    users: list[dict[str, Any]],
+) -> tuple[dict[str, Any], dict[str, Any], dict[str, Any]]:
+    """Build lookup tables from the user sync-info list.
+
+    Args:
+        users: List of user dicts as returned by :func:`get_ayon_user_sync_info`.
+
+    Returns:
+        Three dicts keyed by kitsu_id, email, and AYON username respectively.
+    """
+    by_kitsu_id: dict[str, Any] = {}
+    by_email: dict[str, Any] = {}
+    by_name: dict[str, Any] = {}
+    for u in users:
+        if u.get("kitsu_id"):
+            by_kitsu_id[u["kitsu_id"]] = u
+        if u.get("email"):
+            by_email[u["email"]] = u
+        if u.get("name"):
+            by_name[u["name"]] = u
+    return by_kitsu_id, by_email, by_name
+
+
+def person_needs_sync(
+    person: dict[str, Any],
+    ayon_users_by_kitsu_id: dict[str, Any],
+    ayon_users_by_email: dict[str, Any],
+    ayon_users_by_name: dict[str, Any],
+) -> bool:
+    """Return whether a Kitsu person should be pushed to AYON.
+
+    Matching priority:
+    1. ``kitsuId`` — the canonical link once a user has been synced at least once.
+    2. Email — fallback for users synced before kitsuId tracking.
+    3. Derived username — if a username-only match is found, it means
+       this is a duplicate Kitsu account for the same AYON user and is skipped.
+
+    A matched user is considered up-to-date when its ``fullName`` matches
+    ``person["full_name"]``.  Derived username is intentionally not compared
+    because renaming AYON users can have side effects.
+
+    Args:
+        person: Kitsu person dict (from ``gazu.person.all_persons()``).
+        ayon_users_by_kitsu_id: Lookup keyed by kitsu_id.
+        ayon_users_by_email: Lookup keyed by email.
+        ayon_users_by_name: Lookup keyed by AYON username.
+
+    Returns:
+        ``True`` if the person should be pushed to AYON, ``False`` to skip.
+    """
+    kitsu_id = person.get("id", "")
+    email = person.get("email", "")
+    username = to_username(
+        person.get("first_name", ""),
+        person.get("last_name") or None,
+    )
+
+    id_match_ayon_user = ayon_users_by_kitsu_id.get(kitsu_id)
+    email_match_ayon_user = ayon_users_by_email.get(email)
+    existing_ayon_user = id_match_ayon_user or email_match_ayon_user or ayon_users_by_name.get(username)
+
+    if not existing_ayon_user:
+        return True
+    elif not id_match_ayon_user and not email_match_ayon_user:
+        # Username-only match — duplicate Kitsu account, always skip.
+        # i.e two "John Doe" (username `john.doe`) users with different emails.
+        return False
+
+    return (
+        existing_ayon_user.get("full_name") != person.get("full_name")
+        or existing_ayon_user.get("active") != person.get("active")
+    )
+
+
+def get_persons(entrypoint: str) -> list[dict]:
+    """Return Kitsu persons that are new or changed compared to AYON users.
+
+    Args:
+        entrypoint: Base addon REST path forwarded to :func:`get_ayon_user_sync_info`.
+    """
+    users = get_ayon_user_sync_info(entrypoint)
+    by_kitsu_id, by_email, by_name = build_ayon_user_lookups(users)
+    return [
+        person
+        for person in gazu.person.all_persons()
+        if person_needs_sync(person, by_kitsu_id, by_email, by_name)
+    ]

--- a/services/processor/processor/utils.py
+++ b/services/processor/processor/utils.py
@@ -81,7 +81,7 @@ def preprocess_task(
 
 def _remove_accents(s: str) -> str:
     """Strip diacritics and normalize special characters for AYON usernames.
-    
+
     Args:
         s: The string to remove accents from.
 
@@ -91,9 +91,18 @@ def _remove_accents(s: str) -> str:
     nfkd = unicodedata.normalize("NFKD", s)
     result = "".join(c for c in nfkd if not unicodedata.combining(c))
     replacement_map = {
-        "Æ": "AE", "Ð": "D", "Ø": "O", "Þ": "TH",
-        "ß": "ss", "æ": "ae", "ð": "d", "ø": "o", "þ": "th",
-        "Œ": "OE", "œ": "oe", "ƒ": "f",
+        "Æ": "AE",
+        "Ð": "D",
+        "Ø": "O",
+        "Þ": "TH",
+        "ß": "ss",
+        "æ": "ae",
+        "ð": "d",
+        "ø": "o",
+        "þ": "th",
+        "Œ": "OE",
+        "œ": "oe",
+        "ƒ": "f",
     }
     for k, v in replacement_map.items():
         result = result.replace(k, v)
@@ -159,7 +168,8 @@ def build_ayon_user_lookups(
     """Build lookup tables from the user sync-info list.
 
     Args:
-        users: List of user dicts as returned by :func:`get_ayon_user_sync_info`.
+        users: List of user dicts as returned by
+            :func:`get_ayon_user_sync_info`.
 
     Returns:
         Three dicts keyed by kitsu_id, email, and AYON username respectively.
@@ -186,7 +196,7 @@ def person_needs_sync(
     """Return whether a Kitsu person should be pushed to AYON.
 
     Matching priority:
-    1. ``kitsuId`` — the canonical link once a user has been synced at least once.
+    1. ``kitsuId`` — canonical link once a user has been synced at least once.
     2. Email — fallback for users synced before kitsuId tracking.
     3. Derived username — if a username-only match is found, it means
        this is a duplicate Kitsu account for the same AYON user and is skipped.
@@ -213,7 +223,11 @@ def person_needs_sync(
 
     id_match_ayon_user = ayon_users_by_kitsu_id.get(kitsu_id)
     email_match_ayon_user = ayon_users_by_email.get(email)
-    existing_ayon_user = id_match_ayon_user or email_match_ayon_user or ayon_users_by_name.get(username)
+    existing_ayon_user = (
+        id_match_ayon_user
+        or email_match_ayon_user
+        or ayon_users_by_name.get(username)
+    )
 
     if not existing_ayon_user:
         return True
@@ -233,7 +247,7 @@ def get_persons(entrypoint: str) -> list[dict]:
     """Return Kitsu persons that are new or changed compared to AYON users.
 
     Args:
-        entrypoint: Base addon REST path forwarded to :func:`get_ayon_user_sync_info`.
+        entrypoint: REST forwarded to :func:`get_ayon_user_sync_info`.
     """
     users = get_ayon_user_sync_info(entrypoint)
     by_kitsu_id, by_email, by_name = build_ayon_user_lookups(users)

--- a/services/processor/processor/utils.py
+++ b/services/processor/processor/utils.py
@@ -224,7 +224,9 @@ def person_needs_sync(
     id_match_ayon_user = ayon_users_by_kitsu_id.get(kitsu_id)
     email_match_ayon_user = ayon_users_by_email.get(email)
     name_match_ayon_user = ayon_users_by_name.get(username)
-    existing_ayon_user = id_match_ayon_user or email_match_ayon_user or name_match_ayon_user
+    existing_ayon_user = (
+        id_match_ayon_user or email_match_ayon_user or name_match_ayon_user
+    )
 
     if not existing_ayon_user:
         return True
@@ -233,8 +235,12 @@ def person_needs_sync(
     if not id_match_ayon_user and not existing_ayon_user.get("kitsu_id"):
         return True
 
-    if name_match_ayon_user and not id_match_ayon_user and not email_match_ayon_user:
-        # Username-only match with an already-linked user => duplicate Kitsu account.
+    if (
+        name_match_ayon_user
+        and not id_match_ayon_user
+        and not email_match_ayon_user
+    ):
+        # Username-only match with already-linked user: duplicate Kitsu account
         return False
 
     return (

--- a/services/processor/processor/utils.py
+++ b/services/processor/processor/utils.py
@@ -223,17 +223,18 @@ def person_needs_sync(
 
     id_match_ayon_user = ayon_users_by_kitsu_id.get(kitsu_id)
     email_match_ayon_user = ayon_users_by_email.get(email)
-    existing_ayon_user = (
-        id_match_ayon_user
-        or email_match_ayon_user
-        or ayon_users_by_name.get(username)
-    )
+    name_match_ayon_user = ayon_users_by_name.get(username)
+    existing_ayon_user = id_match_ayon_user or email_match_ayon_user or name_match_ayon_user
 
     if not existing_ayon_user:
         return True
-    elif not id_match_ayon_user and not email_match_ayon_user:
-        # Username-only match — duplicate Kitsu account, always skip.
-        # i.e two "John Doe" (username `john.doe`) users with different emails.
+
+    # Backfill kitsu_id on legacy users matched by email/username.
+    if not id_match_ayon_user and not existing_ayon_user.get("kitsu_id"):
+        return True
+
+    if name_match_ayon_user and not id_match_ayon_user and not email_match_ayon_user:
+        # Username-only match with an already-linked user => duplicate Kitsu account.
         return False
 
     return (

--- a/services/processor/processor/utils.py
+++ b/services/processor/processor/utils.py
@@ -225,6 +225,7 @@ def person_needs_sync(
     return (
         existing_ayon_user.get("full_name") != person.get("full_name")
         or existing_ayon_user.get("active") != person.get("active")
+        or existing_ayon_user.get("email") != person.get("email", "")
     )
 
 

--- a/services/processor/processor/utils.py
+++ b/services/processor/processor/utils.py
@@ -250,7 +250,7 @@ def person_needs_sync(
     )
 
 
-def get_persons(entrypoint: str) -> list[dict]:
+def get_persons_to_update(entrypoint: str) -> list[dict]:
     """Return Kitsu persons that are new or changed compared to AYON users.
 
     Args:

--- a/tests/tests/test_update_from_kitsu.py
+++ b/tests/tests/test_update_from_kitsu.py
@@ -1,16 +1,20 @@
 from pprint import pprint
 
+import ayon_api
+import pytest
 from processor import update_from_kitsu
 
 from . import mock_data
 from .fixtures import (
     PROJECT_ID,
     PROJECT_NAME,
+    access_group,
     api,
     gazu,
     init_data,
     kitsu_url,
     processor,
+    users_enabled,
 )
 
 """ tests for services/processor/update_from_kitsu.py
@@ -192,3 +196,150 @@ def test_delete_task(api, gazu, processor, monkeypatch):
     assert res.status_code == 200
     pprint(res.data)
     assert task["id"] in res.data["tasks"]
+
+
+def test_create_or_update_person_new(
+    api, gazu, kitsu_url, processor, monkeypatch, users_enabled, access_group
+):
+    """A brand new Kitsu person (unknown kitsu_id/email) should be pushed."""
+    new_person = {
+        **mock_data.all_persons[0],
+        "id": "person-id-new-1",
+        "email": "new.person@temp.com",
+        "first_name": "New",
+        "last_name": "Person",
+        "full_name": "New Person",
+    }
+    api.delete("/users/new.person")
+    monkeypatch.setattr(gazu.person, "get_person", lambda x: new_person)
+
+    data = {"person_id": new_person["id"]}
+    res = update_from_kitsu.create_or_update_person(processor, data)
+
+    assert res is not None
+    assert res.status_code == 200
+
+    user = api.get_user("new.person")
+    assert user["data"]["kitsuId"] == "person-id-new-1"
+    assert user["attrib"]["fullName"] == "New Person"
+
+    api.delete("/users/new.person")
+
+
+def test_create_or_update_person_skips_when_unchanged(
+    api, gazu, kitsu_url, processor, monkeypatch, mocker, users_enabled, access_group
+):
+    """A person whose AYON data already matches Kitsu should not push."""
+    person = {
+        **mock_data.all_persons[0],
+        "id": "person-id-unchanged-1",
+        "email": "unchanged.person@temp.com",
+        "first_name": "Unchanged",
+        "last_name": "Person",
+        "full_name": "Unchanged Person",
+        "active": True,
+    }
+    api.delete("/users/unchanged.person")
+    monkeypatch.setattr(gazu.person, "get_person", lambda x: person)
+
+    data = {"person_id": person["id"]}
+    # first call creates the user in AYON
+    res = update_from_kitsu.create_or_update_person(processor, data)
+    assert res.status_code == 200
+
+    # second call with identical data should be skipped (no push)
+    post_mock = mocker.patch.object(ayon_api, "post")
+    res = update_from_kitsu.create_or_update_person(processor, data)
+    assert res is None
+    post_mock.assert_not_called()
+
+    api.delete("/users/unchanged.person")
+
+
+def test_create_or_update_person_pushes_when_full_name_changes(
+    api, gazu, kitsu_url, processor, monkeypatch, users_enabled, access_group
+):
+    """Changing full_name in Kitsu should update AYON without renaming
+    the user's username."""
+    person = {
+        **mock_data.all_persons[0],
+        "id": "person-id-changed-1",
+        "email": "changed.person@temp.com",
+        "first_name": "Changed",
+        "last_name": "Person",
+        "full_name": "Changed Person",
+    }
+    api.delete("/users/changed.person")
+    monkeypatch.setattr(gazu.person, "get_person", lambda x: person)
+
+    data = {"person_id": person["id"]}
+    res = update_from_kitsu.create_or_update_person(processor, data)
+    assert res.status_code == 200
+
+    updated_person = {**person, "full_name": "Changed Person Renamed"}
+    monkeypatch.setattr(gazu.person, "get_person", lambda x: updated_person)
+    res = update_from_kitsu.create_or_update_person(processor, data)
+    assert res is not None
+    assert res.status_code == 200
+
+    user = api.get_user("changed.person")
+    assert user["attrib"]["fullName"] == "Changed Person Renamed"
+    assert user["name"] == "changed.person"  # username must not change
+
+    api.delete("/users/changed.person")
+
+
+def test_delete_person_sends_expected_payload(processor, mocker):
+    """delete_person must call /remove with an empty project_name and a
+    'Person' typed entity — it must not require a paired project."""
+    post_mock = mocker.patch.object(ayon_api, "post")
+
+    data = {"person_id": "person-id-payload-1"}
+    update_from_kitsu.delete_person(processor, data)
+
+    post_mock.assert_called_once()
+    args, kwargs = post_mock.call_args
+    assert args[0] == f"{processor.entrypoint}/remove"
+    assert kwargs["project_name"] == ""
+    assert kwargs["entities"] == [
+        {
+            "id": "person-id-payload-1",
+            "type": "Person",
+            "ayon_server_url": ayon_api.get_base_url(),
+        }
+    ]
+
+
+def test_delete_person_removes_user_without_paired_project(
+    api, gazu, kitsu_url, processor, monkeypatch, users_enabled, access_group
+):
+    """delete_person should remove the AYON user even when the Kitsu
+    project is not paired with any AYON project."""
+    person = {
+        **mock_data.all_persons[0],
+        "id": "person-id-delete-1",
+        "email": "delete.person@temp.com",
+        "first_name": "Delete",
+        "last_name": "Person",
+        "full_name": "Delete Person",
+    }
+    api.delete("/users/delete.person")
+    monkeypatch.setattr(gazu.person, "get_person", lambda x: person)
+
+    data = {"person_id": person["id"]}
+    res = update_from_kitsu.create_or_update_person(processor, data)
+    assert res.status_code == 200
+    api.get_user("delete.person")  # should not raise
+
+    class UnpairedProcessor:
+        entrypoint = processor.entrypoint
+
+        def get_paired_ayon_project(self, kitsu_project_id):
+            return None
+
+    res = update_from_kitsu.delete_person(UnpairedProcessor(), data)
+    assert res.status_code == 200
+
+    with pytest.raises(Exception) as exc_info:
+        api.get_user("delete.person")
+    assert str(exc_info.value).startswith("404 Client Error: Not Found for url:")

--- a/tests/tests/test_users.py
+++ b/tests/tests/test_users.py
@@ -1,0 +1,97 @@
+"""tests for endpoint 'api/addons/kitsu/{version}/users'
+
+$ poetry run pytest tests/test_users.py
+"""
+
+from .fixtures import (
+    PROJECT_NAME,
+    access_group,
+    api,
+    kitsu_url,
+    users,
+    users_enabled,
+)
+
+EXPECTED_KEYS = {"name", "kitsu_id", "email", "full_name", "active"}
+
+
+def test_list_users_shape(api, kitsu_url, users):
+    """The /users endpoint must return the exact fields the processor
+    relies on for change detection."""
+    res = api.get(f"{kitsu_url}/users")
+    assert res.status_code == 200
+    assert isinstance(res.data, list)
+    assert res.data, "expected at least one AYON user"
+
+    for user in res.data:
+        assert set(user.keys()) == EXPECTED_KEYS
+        assert isinstance(user["name"], str)
+        assert isinstance(user["active"], bool)
+
+
+def test_list_users_reflects_kitsu_person_sync_fields(
+    api, kitsu_url, users_enabled, access_group
+):
+    """kitsu_id/full_name/email in /users must mirror what /push wrote
+    to data.kitsuId / attrib.fullName / attrib.email."""
+    entity = {
+        "email": "sync.info.user@temp.com",
+        "first_name": "Sync",
+        "last_name": "InfoUser",
+        "full_name": "Sync InfoUser",
+        "id": "person-id-sync-info-1",
+        "type": "Person",
+        "role": "user",
+        "active": True,
+    }
+    api.delete("/users/sync.infouser")
+
+    res = api.post(
+        f"{kitsu_url}/push", project_name=PROJECT_NAME, entities=[entity]
+    )
+    assert res.status_code == 200
+
+    try:
+        res = api.get(f"{kitsu_url}/users")
+        assert res.status_code == 200
+
+        user = next(u for u in res.data if u["name"] == "sync.infouser")
+        assert user["kitsu_id"] == "person-id-sync-info-1"
+        assert user["full_name"] == "Sync InfoUser"
+        assert user["email"] == "sync.info.user@temp.com"
+        assert user["active"] is True
+    finally:
+        api.delete("/users/sync.infouser")
+
+
+def test_list_users_includes_inactive_users(
+    api, kitsu_url, users_enabled, access_group
+):
+    """Inactive AYON users must still be returned so Kitsu deactivations
+    can be detected and mirrored (see get_user_sync_list docstring)."""
+    entity = {
+        "email": "inactive.user@temp.com",
+        "first_name": "Inactive",
+        "last_name": "User",
+        "full_name": "Inactive User",
+        "id": "person-id-inactive-1",
+        "type": "Person",
+        "role": "user",
+        "active": False,
+    }
+    api.delete("/users/inactive.user")
+
+    res = api.post(
+        f"{kitsu_url}/push", project_name=PROJECT_NAME, entities=[entity]
+    )
+    assert res.status_code == 200
+
+    try:
+        res = api.get(f"{kitsu_url}/users")
+        assert res.status_code == 200
+
+        names = {u["name"]: u for u in res.data}
+        assert "inactive.user" in names
+        assert names["inactive.user"]["active"] is False
+    finally:
+        api.delete("/users/inactive.user")


### PR DESCRIPTION
## Changelog Description
Optimize sync by not reprocessing not changed users, fix listener user deletion and prevent from changing `username`.

## Additional review information
You may witness pushed operations are logged three times on server side
```
2026-06-15T16:27:34.623923350Z INFO    kitsu-1-2-7-dev-user-sync.kitsu.push | Synced 7841 entities in 30.270172119140625s
2026-06-15T16:27:43.301653472Z INFO    kitsu-1-2-7-dev-user-sync.kitsu.push | Synced 7841 entities in 28.51426935195923s
2026-06-15T16:27:55.188665001Z INFO    kitsu-1-2-7-dev-user-sync.kitsu.push | Synced 7841 entities in 29.74278712272644s
```
This is because of a timeout and retry issue handled in another PR: https://github.com/ynput/ayon-kitsu/pull/133

## Testing notes:
You have to push addon code on server and set the version to the production bundle.

### Full sync
1. Create a new user in Kitsu or change name or email in Kitsu
2. Run processor locally and wait for it to complete, may take several minutes depending on the size of the projects.

### Listener
1. Run processor locally.
1. Create a new user in Kitsu or change name or email in Kitsu
