### PR TITLE
Fix: Push performed three times

### DIFF
--- a/services/processor/processor/fullsync.py
+++ b/services/processor/processor/fullsync.py
@@ -146,6 +146,42 @@ def get_casting_links(
     return casting_entities
 
 
+# Generous timeout for the bulk /push request. The server processes the whole
+# entity batch in a single request which can take over the ayon_api default
+# of 10s for a full sync. Too short a timeout makes the client stop and retry,
+# causing the server to reprocess the entire batch repeatedly.
+PUSH_TIMEOUT = 600
+
+
+def push_entities(
+    parent: "KitsuProcessor",
+    project_name: str,
+    entities: list[dict[str, Any]],
+):
+    """POST entities to the addon /push endpoint.
+
+    Uses a long timeout and disables retries: the push is a large,
+    non-idempotent bulk operation, so re-sending it on a slow
+    connection would make the server reprocess every entity again.
+
+    Args:
+        parent: The parent processor
+        project_name: The Ayon project name
+        entities: The list of entities to push
+    """
+    con = ayon_api.get_server_api_connection()
+    prev_max_retries = con.max_retries
+    con.set_max_retries(1)
+    try:
+        return con.raw_post(
+            f"{parent.entrypoint}/push",
+            json={"project_name": project_name, "entities": entities},
+            timeout=PUSH_TIMEOUT,
+        )
+    finally:
+        con.set_max_retries(prev_max_retries)
+
+
 def project_full_sync(
     parent: "KitsuProcessor", kitsu_project_id: str, project_name: str
 ):
@@ -192,11 +228,7 @@ def project_full_sync(
     for entity in entities:
         entity["ayon_server_url"] = ayon_api.get_base_url()
 
-    ayon_api.post(
-        f"{parent.entrypoint}/push",
-        project_name=project_name,
-        entities=entities,
-    )
+    push_entities(parent, project_name, entities)
     logging.info(
         f"Full Sync for project {project_name}"
         f" completed in {time.time() - start_time}s"


### PR DESCRIPTION
## Changelog Description
Prevent `push` entities to be performed 3 times.

## Additional review information
Because of the large size and the short timeout, it may take very long to perform a `push`, it fails and tries 3 times, which overloads the server with useless requests.

You can see it by
```
2026-06-15T16:27:34.623923350Z INFO    kitsu-1-2-7-dev-user-sync.kitsu.push | Synced 7841 entities in 30.270172119140625s
2026-06-15T16:27:43.301653472Z INFO    kitsu-1-2-7-dev-user-sync.kitsu.push | Synced 7841 entities in 28.51426935195923s
2026-06-15T16:27:55.188665001Z INFO    kitsu-1-2-7-dev-user-sync.kitsu.push | Synced 7841 entities in 29.74278712272644s
```

*⚠️ I'm actually not very convinced by this approach, I think it'd be better to split pushes by type (users; folders; tasks...) sequentially. It's more work but cleaner IMO. Submitted PR to open discussion about that.*

## Testing notes:
1. Run full sync for a large project.
