### PR TITLE
Optim: sync tasks

### DIFF
--- a/services/processor/processor/fullsync.py
+++ b/services/processor/processor/fullsync.py
@@ -31,12 +31,14 @@ def get_tasks(
     kitsu_project_id: str,
     task_types: dict[str, str],
     task_statuses: dict[str, str],
+    persons: list[dict[str, Any]],
 ) -> list[dict[str, str]]:
     persons_by_id: dict[str, dict] = {
-        p["id"]: p for p in gazu.person.all_persons()
+        p["id"]: p for p in persons
     }
 
     tasks: list[dict[str, str]] = []
+    ayon_users_by_email = get_ayon_users_by_email()
     for record in gazu.task.all_tasks_for_project(kitsu_project_id):
         record["persons"] = [
             {"email": persons_by_id[assignee_id]["email"]}
@@ -48,7 +50,7 @@ def get_tasks(
                 record,
                 task_types,
                 task_statuses,
-                get_ayon_users_by_email(),
+                ayon_users_by_email,
             )
         )
     return tasks
@@ -172,7 +174,7 @@ def project_full_sync(
     persons = gazu.person.all_persons()
 
     assets = get_assets(kitsu_project_id, asset_types)
-    tasks = get_tasks(kitsu_project_id, task_types, task_statuses)
+    tasks = get_tasks(kitsu_project_id, task_types, task_statuses, persons)
     sync_casting_settings = (
         parent.settings.get("sync_settings", {})
         .get("sync_casting", {})

--- a/services/processor/processor/fullsync.py
+++ b/services/processor/processor/fullsync.py
@@ -10,6 +10,7 @@ if TYPE_CHECKING:
 
 from .utils import (
     get_asset_types,
+    get_ayon_users_by_email,
     get_statuses,
     get_task_types,
     preprocess_asset,
@@ -29,18 +30,25 @@ def get_assets(
 def get_tasks(
     kitsu_project_id: str,
     task_types: dict[str, str],
-    task_statuses: dict[str, str]
+    task_statuses: dict[str, str],
 ) -> list[dict[str, str]]:
+    persons_by_id: dict[str, dict] = {
+        p["id"]: p for p in gazu.person.all_persons()
+    }
+
     tasks: list[dict[str, str]] = []
     for record in gazu.task.all_tasks_for_project(kitsu_project_id):
-        record["persons"]: list[dict[str, str]] = []
-        for id in record["assignees"]:
-            record["persons"].append({
-                "email": gazu.person.get_person(id)["email"]
-            })
+        record["persons"] = [
+            {"email": persons_by_id[assignee_id]["email"]}
+            for assignee_id in record["assignees"]
+            if assignee_id in persons_by_id
+        ]
         tasks.append(
             preprocess_task(
-                kitsu_project_id, record, task_types, task_statuses
+                record,
+                task_types,
+                task_statuses,
+                get_ayon_users_by_email(),
             )
         )
     return tasks

--- a/services/processor/processor/update_from_kitsu.py
+++ b/services/processor/processor/update_from_kitsu.py
@@ -199,7 +199,12 @@ def create_or_update_task(parent: "KitsuProcessor", data: dict[str, str]):
         return  # do nothing as this kitsu and ayon project are not paired
 
     entity = gazu.task.get_task(data["task_id"])
-    entity = utils.preprocess_task(entity["project_id"], entity)
+    entity = utils.preprocess_task(
+        entity,
+        utils.get_task_types(entity["project_id"]),
+        utils.get_statuses(),
+        utils.get_ayon_users_by_email()
+    )
 
     # Add ayon base url so we can use it in REST calls later on
     entity["ayon_server_url"] = ayon_api.get_base_url()

--- a/services/processor/processor/utils.py
+++ b/services/processor/processor/utils.py
@@ -28,6 +28,17 @@ def get_statuses() -> dict[str, str]:
     return kitsu_statuses
 
 
+def get_ayon_users_by_email() -> dict[str, str]:
+    """Get AYON users by email.
+
+    Returns:
+        dict[str, str]: A dictionary of AYON users by email.
+    """
+    return {
+        user["attrib"]["email"]: user["name"] for user in ayon_api.get_users()
+    }
+
+
 def preprocess_asset(
     kitsu_project_id: str,
     asset: dict[str, str],
@@ -42,17 +53,11 @@ def preprocess_asset(
 
 
 def preprocess_task(
-    kitsu_project_id: str,
     task: dict[str, str | list[str]],
-    task_types: dict[str, str | list[str]] = {},
-    statuses: dict[str, str] = {},
+    task_types: dict[str, str | list[str]],
+    statuses: dict[str, str],
+    ayon_users_by_email: dict[str, str],
 ) -> dict[str, str | list[str]]:
-    if not task_types:
-        task_types = get_task_types(kitsu_project_id)
-
-    if not statuses:
-        statuses = get_statuses()
-
     if "task_type_id" in task and task["task_type_id"] in task_types:
         task["task_type_name"] = task_types[task["task_type_id"]]
 
@@ -62,14 +67,11 @@ def preprocess_task(
     if "name" in task and "task_type_name" in task and task["name"] == "main":
         task["name"] = task["task_type_name"].lower()
 
-    # Match the assigned ayon user with the assigned kitsu email
-    ayon_users = {
-        user["attrib"]["email"]: user["name"] for user in ayon_api.get_users()
-    }
     task_emails = {user["email"] for user in task["persons"]}
-    task["assignees"] = []
-    task["assignees"].extend(
-        ayon_users[email] for email in task_emails if email in ayon_users
-    )
+    task["assignees"] = [
+        ayon_users_by_email[email]
+        for email in task_emails
+        if email in ayon_users_by_email
+    ]
 
     return task

--- a/services/processor/processor/utils.py
+++ b/services/processor/processor/utils.py
@@ -1,5 +1,7 @@
 """ utils shared between fullsync.py and update_from_kitsu.py """
 
+from typing import Any
+
 import ayon_api
 import gazu
 
@@ -53,11 +55,11 @@ def preprocess_asset(
 
 
 def preprocess_task(
-    task: dict[str, str | list[str]],
-    task_types: dict[str, str | list[str]],
+    task: dict[str, Any],
+    task_types: dict[str, str],
     statuses: dict[str, str],
     ayon_users_by_email: dict[str, str],
-) -> dict[str, str | list[str]]:
+) -> dict[str, Any]:
     if "task_type_id" in task and task["task_type_id"] in task_types:
         task["task_type_name"] = task_types[task["task_type_id"]]
 

--- a/services/processor/processor/utils.py
+++ b/services/processor/processor/utils.py
@@ -4,7 +4,6 @@ import re
 import unicodedata
 from typing import Iterable, Optional, Any
 
-from typing import Any
 
 import ayon_api
 import gazu

--- a/tests/tests/test_fullsync.py
+++ b/tests/tests/test_fullsync.py
@@ -93,6 +93,7 @@ def test_get_tasks(gazu, monkeypatch):
         PROJECT_ID,
         {"task-type-id-1": "Animation", "task-type-id-2": "Compositing"},
         {"task-status-id-1": "Todo", "task-status-id-2": "Approved"},
+        mock_data.all_persons,
     )
     # assert len(res) == 2
     # assert res[0]['id'] == "task-id-1"


### PR DESCRIPTION
## Changelog Description
Optimize tasks full sync by fetching all users (ayon and Kitsu) only once before matching them. Also made `preprocess_task` signature clearer.

## Additional review information
When syncing a lot of tasks, performing `ayon_api.get_users()` for each `preprocess_task` or `gazu.person.get_person(id)` for each task record is hugely expensive and unecessary.

## Testing notes:
### Fullsync
1. Stop running processor
2. Change a task status or assignee in Kitsu
3. Perform full sync, when done, see the change performed in Ayon

### Listener
1. Run the processor
2. Change a task status or assignee in Kitsu
3. See the change
