### PR TITLE
Bugfix: Asset deleted in Kitsu not deleted in Ayon

### DIFF
--- a/server/kitsu/push.py
+++ b/server/kitsu/push.py
@@ -933,12 +933,7 @@ async def remove_entities(
             if not folder:
                 continue
 
-            await delete_folder(
-                project_name=p.name,
-                folder_id=folder.id,
-                user=user,
-                force=True,
-            )
+            await folder.delete(force=True)
             logging.info(f"Deleted {entity_dict['type']} '{folder.name}'")
             folders[entity_dict["id"]] = folder.id
 

--- a/server/kitsu/push.py
+++ b/server/kitsu/push.py
@@ -11,6 +11,7 @@ from ayon_server.entities import FolderEntity, ProjectEntity, UserEntity
 from ayon_server.helpers.deploy_project import anatomy_to_project_data
 from ayon_server.lib.postgres import Postgres
 from ayon_server.types import Field, OPModel
+from ayon_server.products import delete_product
 
 from .anatomy import get_kitsu_project_anatomy, parse_attrib
 from .constants import (
@@ -33,7 +34,6 @@ from .utils import (
     update_folder,
     update_task,
 )
-from ayon_api import get_products, delete_product
 
 
 from .addon_helpers import to_username, required_values
@@ -968,10 +968,9 @@ async def remove_entities(
                             )
                         )
 
-            for product in get_products(
-                project.name, folder_ids=[folder.id], fields=["id"]
-            ):
-                delete_product(project.name, product["id"])
+            for product in folder.data.get("products"):
+                logging.info(f"deleting product {product.get('name')} for folder {folder.id}")
+                delete_product(user, project.name, product["id"])
 
             await delete_folder(
                 project_name=project.name,

--- a/server/kitsu/push.py
+++ b/server/kitsu/push.py
@@ -11,7 +11,6 @@ from ayon_server.entities import FolderEntity, ProjectEntity, UserEntity
 from ayon_server.helpers.deploy_project import anatomy_to_project_data
 from ayon_server.lib.postgres import Postgres
 from ayon_server.types import Field, OPModel
-from ayon_server.products import delete_product
 
 from .anatomy import get_kitsu_project_anatomy, parse_attrib
 from .constants import (
@@ -943,40 +942,7 @@ async def remove_entities(
                 or "breakdown"
             )
 
-            async with asyncio.TaskGroup() as group:
-                for link in await get_links_for_output(
-                    project.name,
-                    folder.id,
-                    f"{link_type}|folder|folder",
-                ):
-                    # Try to get asset_kitsu_id from link data
-                    link_data = link.get("data")
-                    kitsu_asset_id = (
-                        link_data["kitsuAssetId"] if link_data else None
-                    )
-
-                    if (
-                        kitsu_asset_id
-                        and folder.data.get("kitsuId") == kitsu_asset_id
-                    ):
-                        group.create_task(
-                            delete_entity_link(
-                                project.name,
-                                user,
-                                entity_dict["ayon_server_url"],
-                                link["id"],
-                            )
-                        )
-
-            for product in folder.data.get("products"):
-                logging.info(f"deleting product {product.get('name')} for folder {folder.id}")
-                delete_product(user, project.name, product["id"])
-
-            await delete_folder(
-                project_name=project.name,
-                folder_id=folder.id,
-                user=user,
-            )
+            folder.delete(force=True)
             logging.info(f"Deleted {entity_dict['type']} '{folder.name}'")
             folders[entity_dict["id"]] = folder.id
 

--- a/server/kitsu/push.py
+++ b/server/kitsu/push.py
@@ -1,5 +1,6 @@
 import json
 import time
+import asyncio
 from typing import TYPE_CHECKING, Any, Literal, get_args
 
 import httpx
@@ -935,6 +936,36 @@ async def remove_entities(
             )
             if not folder:
                 continue
+
+            link_type = (
+                settings.sync_settings.sync_casting.casting_link_type
+                or "breakdown"
+            )
+
+            async with asyncio.TaskGroup() as group:
+                for link in await get_links_for_output(
+                    project.name,
+                    folder.id,
+                    f"{link_type}|folder|folder",
+                ):
+                    # Try to get asset_kitsu_id from link data
+                    link_data = link.get("data")
+                    kitsu_asset_id = (
+                        link_data["kitsuAssetId"] if link_data else None
+                    )
+
+                    if (
+                        kitsu_asset_id
+                        and folder.data.get("kitsuId") == kitsu_asset_id
+                    ):
+                        group.create_task(
+                            delete_entity_link(
+                                project.name,
+                                user,
+                                entity_dict["ayon_server_url"],
+                                link["id"],
+                            )
+                        )
 
             await delete_folder(
                 project_name=project.name,

--- a/server/kitsu/push.py
+++ b/server/kitsu/push.py
@@ -21,7 +21,6 @@ from .utils import (
     create_folder,
     create_task,
     delete_entity_link,
-    delete_folder,
     delete_task,
     get_folder_by_kitsu_id,
     get_links_for_output,

--- a/server/kitsu/push.py
+++ b/server/kitsu/push.py
@@ -1,6 +1,5 @@
 import json
 import time
-import asyncio
 from typing import TYPE_CHECKING, Any, Literal, get_args
 
 import httpx
@@ -936,11 +935,6 @@ async def remove_entities(
             )
             if not folder:
                 continue
-
-            link_type = (
-                settings.sync_settings.sync_casting.casting_link_type
-                or "breakdown"
-            )
 
             folder.delete(force=True)
             logging.info(f"Deleted {entity_dict['type']} '{folder.name}'")

--- a/server/kitsu/push.py
+++ b/server/kitsu/push.py
@@ -936,7 +936,7 @@ async def remove_entities(
             if not folder:
                 continue
 
-            folder.delete(force=True)
+            await folder.delete(force=True)
             logging.info(f"Deleted {entity_dict['type']} '{folder.name}'")
             folders[entity_dict["id"]] = folder.id
 

--- a/server/kitsu/push.py
+++ b/server/kitsu/push.py
@@ -33,6 +33,7 @@ from .utils import (
     update_folder,
     update_task,
 )
+from ayon_api import get_products, delete_product
 
 
 from .addon_helpers import to_username, required_values
@@ -966,6 +967,11 @@ async def remove_entities(
                                 link["id"],
                             )
                         )
+
+            for product in get_products(
+                project.name, folder_ids=[folder.id], fields=["id"]
+            ):
+                delete_product(project.name, product["id"])
 
             await delete_folder(
                 project_name=project.name,


### PR DESCRIPTION
## Changelog Description
When deleting an asset in Kitsu, the corresponding folder in Ayon will not be deleted if a product exists. This fix ensure the folder is deleted even in this scenario.

## Additional review information
Product files on the server are not deleted, so it's still possible to restore them if a mistake has been made.

## Testing notes:
- Ensure you have a running processor using this branch, and the server is also using this branch.
- Create an asset in Kitsu (or choose one you're willing to sacrifice for this test, it doesn't matter).
- Ensure the corresponding Ayon folder has published products, or publish some.
- Delete the asset in Kitsu. The delete button needs to be used twice (first time to archive, second time to delete).
- The corresponding Ayon folder should be deleted.