### PR TITLE
Feature: refresh connection token

### DIFF
--- a/services/processor/processor/processor.py
+++ b/services/processor/processor/processor.py
@@ -36,6 +36,15 @@ if service_name := os.environ.get("AYON_SERVICE_NAME"):
 
 SENDER = f"kitsu-processor-{socket.gethostname()}"
 
+# How often the watchdog checks the Kitsu event client's connection state.
+EVENT_WATCHDOG_INTERVAL = 30
+# Force a full reconnect if the event client has been disconnected for
+# longer than this, rather than letting socketio retry forever with a
+# potentially stale auth token.
+EVENT_WATCHDOG_MAX_DISCONNECTED = 120
+# Delay between reconnect attempts of the Kitsu event client.
+EVENT_RECONNECT_DELAY = 10
+
 
 class KitsuServerError(Exception):
     pass
@@ -133,13 +142,102 @@ class KitsuProcessor:
             "api", "socket.io"
         )
         gazu.set_event_host(self.kitsu_events_url)
-        self.event_client = gazu.events.init()
+        self.event_client = None
 
         # ============= Add Kitsu Event Listeners ==============
-        gazu_listener_thread = threading.Thread(target=self.run_gazu_listeners)
+        # Connects the event client and (re)connects it
+        # whenever the connection drops or the watchdog forces it.
+        gazu_listener_thread = threading.Thread(
+            target=self.run_gazu_listeners, daemon=True
+        )
         gazu_listener_thread.start()
 
+        # python-socketio's own reconnection logic can get stuck
+        # retrying forever using a stale auth header (captured once at
+        # connect time), e.g. after the Kitsu server restarts or the
+        # access token expires. 
+        # This watchdog detects that and forces a clean reconnect.
+        gazu_watchdog_thread = threading.Thread(
+            target=self.watch_gazu_connection, daemon=True
+        )
+        gazu_watchdog_thread.start()
+
     def run_gazu_listeners(self):
+        """(Re)connect the Kitsu event client and listen for events.
+
+        Runs forever in its own thread. Whenever the connection is lost,
+        dropped, or closed by the watchdog, this re-authenticates with Kitsu 
+        (in case the access token has expired) and reconnects.
+        """
+        while True:
+            try:
+                gazu.log_in(
+                    self.kitsu_login_email, self.kitsu_login_password
+                )
+            except Exception:
+                log_traceback(
+                    "Failed to re-login to Kitsu before (re)connecting "
+                    "the event client"
+                )
+                time.sleep(EVENT_RECONNECT_DELAY)
+                continue
+
+            try:
+                self.event_client = gazu.events.init(ssl_verify=True)
+                self.add_gazu_listeners()
+                logging.info("Gazu event listeners added")
+                gazu.events.run_client(self.event_client)
+            except Exception:
+                log_traceback("Gazu event client crashed")
+
+            logging.warning(
+                "Gazu event listener disconnected, reconnecting in "
+                f"{EVENT_RECONNECT_DELAY}s..."
+            )
+            try:
+                if self.event_client is not None:
+                    self.event_client.disconnect()
+            except Exception:
+                pass
+            time.sleep(EVENT_RECONNECT_DELAY)
+
+    def watch_gazu_connection(self):
+        """Force a full reconnect if the event client stays disconnected.
+
+        Disconnecting here causes `run_gazu_listeners` to loop around and
+        reconnect with a freshly logged-in client.
+        """
+        disconnected_since = None
+        while True:
+            time.sleep(EVENT_WATCHDOG_INTERVAL)
+
+            connected = bool(
+                self.event_client and self.event_client.connected
+            )
+            if connected:
+                disconnected_since = None
+                continue
+
+            if disconnected_since is None:
+                disconnected_since = time.time()
+                continue
+
+            if (
+                time.time() - disconnected_since
+                > EVENT_WATCHDOG_MAX_DISCONNECTED
+            ):
+                logging.warning(
+                    "Kitsu event client has been disconnected for over "
+                    f"{EVENT_WATCHDOG_MAX_DISCONNECTED}s, forcing "
+                    "reconnect"
+                )
+                try:
+                    self.event_client.disconnect()
+                except Exception:
+                    log_traceback()
+                disconnected_since = None
+
+    def add_gazu_listeners(self):
         gazu.events.add_listener(
             self.event_client,
             "project:update",
@@ -283,8 +381,6 @@ class KitsuProcessor:
                 "concept:delete",
                 lambda data: delete_concept(self, data),
             )
-        logging.info("Gazu event listeners added")
-        gazu.events.run_client(self.event_client)
 
     def get_pairing_list(self):
         """maintain a list of pairings so that we can check


### PR DESCRIPTION
## Changelog Description
Auto refresh connection token.

## Additional review information
There are several cases gazu listener connection could break, this makes sure it is always restored.

## Testing notes:
Actually it is not easily testable by hand...
