### PR TITLE
Fix: Move folder by asset type

### DIFF
--- a/services/processor/processor/fullsync.py
+++ b/services/processor/processor/fullsync.py
@@ -15,6 +15,7 @@ from .utils import (
     preprocess_asset,
     preprocess_task,
 )
+from .update_from_kitsu import move_folders_by_asset_type
 
 
 def get_assets(
@@ -197,6 +198,10 @@ def project_full_sync(
         project_name=project_name,
         entities=entities,
     )
+
+    # Re-parent assets whose type changed while the processor was offline
+    move_folders_by_asset_type(project_name, assets)
+
     logging.info(
         f"Full Sync for project {project_name}"
         f" completed in {time.time() - start_time}s"

--- a/services/processor/processor/fullsync.py
+++ b/services/processor/processor/fullsync.py
@@ -15,7 +15,7 @@ from .utils import (
     preprocess_asset,
     preprocess_task,
 )
-from .update_from_kitsu import move_folders_by_asset_type
+from .utils import move_folders_by_asset_type
 
 
 def get_assets(

--- a/services/processor/processor/update_from_kitsu.py
+++ b/services/processor/processor/update_from_kitsu.py
@@ -2,139 +2,12 @@ from typing import TYPE_CHECKING, Any
 
 import ayon_api
 import gazu
-from nxtools import logging, slugify
+from nxtools import logging
 
 from . import utils
 
 if TYPE_CHECKING:
     from .processor import KitsuProcessor
-
-
-def _ensure_asset_type_folder(
-    project_name: str,
-    entity_type_id: str,
-    asset_type_name: str,
-    folders_by_kitsu_id: dict[str, dict],
-) -> str | None:
-    """Return the AYON folder id for an asset type, creating it if needed.
-
-    Args:
-        project_name: The name of the AYON project.
-        entity_type_id: The Kitsu entity type id.
-        asset_type_name: The name of the asset type.
-        folders_by_kitsu_id: A dictionary of AYON folders by Kitsu id.
-
-    Returns:
-        The AYON folder id for the asset type.
-    """
-    asset_type_folder = folders_by_kitsu_id.get(entity_type_id)
-    if asset_type_folder:
-        return asset_type_folder["id"]
-
-    assets_root = folders_by_kitsu_id.get("asset")
-    if not assets_root:
-        # Create the Assets folder if it doesn't exist
-        assets_root_id = ayon_api.create_folder(
-            project_name,
-            name="Assets",
-            data={"kitsuId": "asset"},
-        )
-        folders_by_kitsu_id["asset"] = {"id": assets_root_id}
-    else:
-        assets_root_id = assets_root["id"]
-
-    asset_type_folder_id = ayon_api.create_folder(
-        project_name,
-        name=slugify(asset_type_name, separator="_"),
-        label=asset_type_name,
-        parent_id=assets_root_id,
-        data={"kitsuId": entity_type_id},
-    )
-    folders_by_kitsu_id[entity_type_id] = {"id": asset_type_folder_id}
-    return asset_type_folder_id
-
-
-def move_folders_by_asset_type(
-    project_name: str, entities: list[dict[str, Any]]
-) -> None:
-    """Re-parent AYON asset folders when their Kitsu asset type differs.
-
-    Skip moves for folders that already have published products. Leave old
-    asset-type folders in place even if they become empty.
-
-    Args:
-        project_name: The name of the AYON project.
-        entities: List of kitsu entities to process.
-    """
-    entities_ids: set[str] = {"asset"}
-    for entity in entities:
-        if entity.get("id"):
-            entities_ids.add(entity["id"])
-        if entity.get("entity_type_id"):
-            entities_ids.add(entity["entity_type_id"])
-
-    folders_by_kitsu_id = utils.get_ayon_folders_by_kitsu_ids(
-        project_name, entities_ids
-    )
-
-    folders_to_move: list[tuple[dict[str, Any], dict, str]] = []
-    for entity in entities:
-        entity_type_id = entity["entity_type_id"]
-        asset_type_name = entity["asset_type_name"]
-
-        asset_folder = folders_by_kitsu_id.get(entity["id"])
-
-        desired_parent_id = _ensure_asset_type_folder(
-            project_name,
-            entity_type_id,
-            asset_type_name,
-            folders_by_kitsu_id,
-        )
-        if not desired_parent_id:
-            logging.warning(
-                f"Cannot move asset {entity.get('name')}: "
-                "failed to resolve asset type folder"
-            )
-            continue
-
-        if asset_folder.get("parentId") == desired_parent_id:
-            continue
-
-        folders_to_move.append((entity, asset_folder, desired_parent_id))
-
-    if not folders_to_move:
-        return
-
-    folder_ids_with_products = {
-        product["folderId"]
-        for product in ayon_api.get_products(
-            project_name,
-            folder_ids=[
-                asset_folder["id"] for _, asset_folder, _ in folders_to_move
-            ],
-            fields={"folderId"},
-        )
-    }
-
-    for entity, asset_folder, desired_parent_id in folders_to_move:
-        if asset_folder["id"] in folder_ids_with_products:
-            logging.warning(
-                f"Skipping move of asset '{entity.get('name')}' to "
-                f"'{entity.get('asset_type_name')}': "
-                "folder has published products"
-            )
-            continue
-
-        logging.info(
-            f"Moving asset '{entity.get('name')}' to asset type "
-            f"'{entity.get('asset_type_name')}'"
-        )
-        ayon_api.update_folder(
-            project_name,
-            asset_folder["id"],
-            parent_id=desired_parent_id,
-        )
-
 
 def update_project(parent: "KitsuProcessor", data: dict[str, str]):
     logging.info(f"update_project: {data}")
@@ -191,7 +64,7 @@ def create_or_update_asset(parent: "KitsuProcessor", data: dict[str, str]):
         entities=[entity],
     )
     # Re-parent after push so the folder is guaranteed to exist in AYON
-    move_folders_by_asset_type(project_name, [entity])
+    utils.move_folders_by_asset_type(project_name, [entity])
     return result
 
 

--- a/services/processor/processor/update_from_kitsu.py
+++ b/services/processor/processor/update_from_kitsu.py
@@ -2,12 +2,136 @@ from typing import TYPE_CHECKING, Any
 
 import ayon_api
 import gazu
-from nxtools import logging
+from nxtools import logging, slugify
 
 from . import utils
 
 if TYPE_CHECKING:
     from .processor import KitsuProcessor
+
+
+def _ensure_asset_type_folder(
+    project_name: str,
+    entity_type_id: str,
+    asset_type_name: str,
+    folders_by_kitsu_id: dict[str, dict],
+) -> str | None:
+    """Return the AYON folder id for an asset type, creating it if needed.
+    
+    Args:
+        project_name: The name of the AYON project.
+        entity_type_id: The Kitsu entity type id.
+        asset_type_name: The name of the asset type.
+        folders_by_kitsu_id: A dictionary of AYON folders by Kitsu id.
+
+    Returns:
+        The AYON folder id for the asset type, or None if the folder cannot be created.
+    """
+    asset_type_folder = folders_by_kitsu_id.get(entity_type_id)
+    if asset_type_folder:
+        return asset_type_folder["id"]
+
+    assets_root = folders_by_kitsu_id.get("asset")
+    if not assets_root:
+        # Create the Assets folder if it doesn't exist
+        assets_root_id = ayon_api.create_folder(
+            project_name,
+            name="Assets",
+            data={"kitsuId": "asset"},
+        )
+        folders_by_kitsu_id["asset"] = {"id": assets_root_id}
+    else:
+        assets_root_id = assets_root["id"]
+
+    asset_type_folder_id = ayon_api.create_folder(
+        project_name,
+        name=slugify(asset_type_name, separator="_"),
+        label=asset_type_name,
+        parent_id=assets_root_id,
+        data={"kitsuId": entity_type_id},
+    )
+    folders_by_kitsu_id[entity_type_id] = {"id": asset_type_folder_id}
+    return asset_type_folder_id
+
+
+def move_folders_by_asset_type(
+    project_name: str, entities: list[dict[str, Any]]
+) -> None:
+    """Re-parent AYON asset folders when their Kitsu asset type differs.
+
+    Skip moves for folders that already have published products. Leave old
+    asset-type folders in place even if they become empty.
+
+    Args:
+        project_name: The name of the AYON project.
+        entities: List of kitsu entities to process.
+    """
+    entities_ids: set[str] = {"asset"}
+    for entity in entities:
+        if entity.get("id"):
+            entities_ids.add(entity["id"])
+        if entity.get("entity_type_id"):
+            entities_ids.add(entity["entity_type_id"])
+
+    folders_by_kitsu_id = utils.get_ayon_folders_by_kitsu_ids(
+        project_name, entities_ids
+    )
+
+    folders_to_move: list[tuple[dict[str, Any], dict, str]] = []
+    for entity in entities:
+        entity_type_id = entity["entity_type_id"]
+        asset_type_name = entity["asset_type_name"]
+
+        asset_folder = folders_by_kitsu_id.get(entity["id"])
+
+        desired_parent_id = _ensure_asset_type_folder(
+            project_name,
+            entity_type_id,
+            asset_type_name,
+            folders_by_kitsu_id,
+        )
+        if not desired_parent_id:
+            logging.warning(
+                f"Cannot move asset {entity.get('name')}: "
+                "failed to resolve asset type folder"
+            )
+            continue
+
+        if asset_folder.get("parentId") == desired_parent_id:
+            continue
+
+        folders_to_move.append((entity, asset_folder, desired_parent_id))
+
+    if not folders_to_move:
+        return
+
+    folder_ids_with_products = {
+        product["folderId"]
+        for product in ayon_api.get_products(
+            project_name,
+            folder_ids=[asset_folder["id"] for _, asset_folder, _ in folders_to_move],
+            fields={"folderId"},
+        )
+    }
+
+    for entity, asset_folder, desired_parent_id in folders_to_move:
+        if asset_folder["id"] in folder_ids_with_products:
+            logging.warning(
+                f"Skipping move of asset '{entity.get('name')}' to "
+                f"'{entity.get('asset_type_name')}': "
+                "folder has published products"
+            )
+            continue
+
+        logging.info(
+            f"Moving asset '{entity.get('name')}' to asset type "
+            f"'{entity.get('asset_type_name')}'"
+        )
+        ayon_api.update_folder(
+            project_name,
+            asset_folder["id"],
+            parent_id=desired_parent_id,
+        )
 
 
 def update_project(parent: "KitsuProcessor", data: dict[str, str]):
@@ -59,11 +183,14 @@ def create_or_update_asset(parent: "KitsuProcessor", data: dict[str, str]):
     # Add ayon base url so we can use it in REST calls later on
     entity["ayon_server_url"] = ayon_api.get_base_url()
 
-    return ayon_api.post(
+    result = ayon_api.post(
         f"{parent.entrypoint}/push",
         project_name=project_name,
         entities=[entity],
     )
+    # Re-parent after push so the folder is guaranteed to exist in AYON
+    move_folders_by_asset_type(project_name, [entity])
+    return result
 
 
 def delete_asset(parent: "KitsuProcessor", data: dict[str, str]):

--- a/services/processor/processor/update_from_kitsu.py
+++ b/services/processor/processor/update_from_kitsu.py
@@ -17,7 +17,7 @@ def _ensure_asset_type_folder(
     folders_by_kitsu_id: dict[str, dict],
 ) -> str | None:
     """Return the AYON folder id for an asset type, creating it if needed.
-    
+
     Args:
         project_name: The name of the AYON project.
         entity_type_id: The Kitsu entity type id.
@@ -25,7 +25,7 @@ def _ensure_asset_type_folder(
         folders_by_kitsu_id: A dictionary of AYON folders by Kitsu id.
 
     Returns:
-        The AYON folder id for the asset type, or None if the folder cannot be created.
+        The AYON folder id for the asset type.
     """
     asset_type_folder = folders_by_kitsu_id.get(entity_type_id)
     if asset_type_folder:
@@ -109,7 +109,9 @@ def move_folders_by_asset_type(
         product["folderId"]
         for product in ayon_api.get_products(
             project_name,
-            folder_ids=[asset_folder["id"] for _, asset_folder, _ in folders_to_move],
+            folder_ids=[
+                asset_folder["id"] for _, asset_folder, _ in folders_to_move
+            ],
             fields={"folderId"},
         )
     }

--- a/services/processor/processor/utils.py
+++ b/services/processor/processor/utils.py
@@ -2,8 +2,6 @@
 
 import re
 import unicodedata
-from typing import Any
-
 from typing import Iterable, Optional, Any
 
 import ayon_api

--- a/services/processor/processor/utils.py
+++ b/services/processor/processor/utils.py
@@ -1,9 +1,10 @@
 """ utils shared between fullsync.py and update_from_kitsu.py """
 
-from typing import Iterable, Optional
+from typing import Iterable, Optional, Any
 
 import ayon_api
 import gazu
+from nxtools import logging, slugify
 
 
 def get_ayon_folders_by_kitsu_ids(
@@ -35,6 +36,132 @@ def get_ayon_folders_by_kitsu_ids(
             if len(result) == len(kitsu_ids):
                 break
     return result
+
+
+def _ensure_asset_type_folder(
+    project_name: str,
+    entity_type_id: str,
+    asset_type_name: str,
+    folders_by_kitsu_id: dict[str, dict],
+) -> str | None:
+    """Return the AYON folder id for an asset type, creating it if needed.
+
+    Args:
+        project_name: The name of the AYON project.
+        entity_type_id: The Kitsu entity type id.
+        asset_type_name: The name of the asset type.
+        folders_by_kitsu_id: A dictionary of AYON folders by Kitsu id.
+
+    Returns:
+        The AYON folder id for the asset type.
+    """
+    asset_type_folder = folders_by_kitsu_id.get(entity_type_id)
+    if asset_type_folder:
+        return asset_type_folder["id"]
+
+    assets_root = folders_by_kitsu_id.get("asset")
+    if not assets_root:
+        # Create the Assets folder if it doesn't exist
+        assets_root_id = ayon_api.create_folder(
+            project_name,
+            name="Assets",
+            data={"kitsuId": "asset"},
+        )
+        folders_by_kitsu_id["asset"] = {"id": assets_root_id}
+    else:
+        assets_root_id = assets_root["id"]
+
+    asset_type_folder_id = ayon_api.create_folder(
+        project_name,
+        name=slugify(asset_type_name, separator="_"),
+        label=asset_type_name,
+        parent_id=assets_root_id,
+        data={"kitsuId": entity_type_id},
+    )
+    folders_by_kitsu_id[entity_type_id] = {"id": asset_type_folder_id}
+    return asset_type_folder_id
+
+
+def move_folders_by_asset_type(
+    project_name: str, entities: list[dict[str, Any]]
+) -> None:
+    """Re-parent AYON asset folders when their Kitsu asset type differs.
+
+    Skip moves for folders that already have published products. Leave old
+    asset-type folders in place even if they become empty.
+
+    Args:
+        project_name: The name of the AYON project.
+        entities: List of kitsu entities to process.
+    """
+    entities_ids: set[str] = {"asset"}
+    for entity in entities:
+        if entity.get("id"):
+            entities_ids.add(entity["id"])
+        if entity.get("entity_type_id"):
+            entities_ids.add(entity["entity_type_id"])
+
+    folders_by_kitsu_id = get_ayon_folders_by_kitsu_ids(
+        project_name, entities_ids
+    )
+
+    folders_to_move: list[tuple[dict[str, Any], dict, str]] = []
+    for entity in entities:
+        entity_type_id = entity["entity_type_id"]
+        asset_type_name = entity["asset_type_name"]
+
+        asset_folder = folders_by_kitsu_id.get(entity["id"])
+
+        desired_parent_id = _ensure_asset_type_folder(
+            project_name,
+            entity_type_id,
+            asset_type_name,
+            folders_by_kitsu_id,
+        )
+        if not desired_parent_id:
+            logging.warning(
+                f"Cannot move asset {entity.get('name')}: "
+                "failed to resolve asset type folder"
+            )
+            continue
+
+        if asset_folder.get("parentId") == desired_parent_id:
+            continue
+
+        folders_to_move.append((entity, asset_folder, desired_parent_id))
+
+    if not folders_to_move:
+        return
+
+    folder_ids_with_products = {
+        product["folderId"]
+        for product in ayon_api.get_products(
+            project_name,
+            folder_ids=[
+                asset_folder["id"] for _, asset_folder, _ in folders_to_move
+            ],
+            fields={"folderId"},
+        )
+    }
+
+    for entity, asset_folder, desired_parent_id in folders_to_move:
+        if asset_folder["id"] in folder_ids_with_products:
+            logging.warning(
+                f"Skipping move of asset '{entity.get('name')}' to "
+                f"'{entity.get('asset_type_name')}': "
+                "folder has published products"
+            )
+            continue
+
+        logging.info(
+            f"Moving asset '{entity.get('name')}' to asset type "
+            f"'{entity.get('asset_type_name')}'"
+        )
+        ayon_api.update_folder(
+            project_name,
+            asset_folder["id"],
+            parent_id=desired_parent_id,
+        )
 
 
 def get_asset_types(kitsu_project_id: str) -> dict[str, str]:

--- a/services/processor/processor/utils.py
+++ b/services/processor/processor/utils.py
@@ -17,10 +17,10 @@ def get_ayon_folders_by_kitsu_ids(
     Args:
         project_name (str): The name of the AYON project.
         kitsu_ids (set[str]): Kitsu ids of the folders to find.
-        folder_types (Optional[Iterable[str]]): An optional iterable of folder types to filter by.
+        folder_types (Optional[Iterable[str]]): Folder types to filter by.
 
     Returns:
-        dict[str, dict]: Mapping of kitsuId -> AYON folder dict for ids that were found.
+        dict[str, dict]: Mapping of kitsuId -> AYON folder dict for found ids.
     """
     result: dict[str, dict] = {}
     for folder in ayon_api.get_folders(

--- a/services/processor/processor/utils.py
+++ b/services/processor/processor/utils.py
@@ -107,10 +107,28 @@ def move_folders_by_asset_type(
 
     folders_to_move: list[tuple[dict[str, Any], dict, str]] = []
     for entity in entities:
-        entity_type_id = entity["entity_type_id"]
-        asset_type_name = entity["asset_type_name"]
+        entity_type_id = entity.get("entity_type_id")
+        asset_type_name = entity.get("asset_type_name")
 
-        asset_folder = folders_by_kitsu_id.get(entity["id"])
+        if not entity_type_id or not asset_type_name:
+            # Asset type couldn't be resolved (e.g. brand new asset type
+            # not yet cached) - nothing to re-parent, skip safely.
+            logging.warning(
+                f"Cannot move asset {entity.get('name')}: "
+                "missing entity_type_id/asset_type_name on entity"
+            )
+            continue
+
+        asset_folder = folders_by_kitsu_id.get(entity.get("id"))
+        if not asset_folder:
+            # The folder may not have been indexed yet (e.g. it was just
+            # created by the /push call). Skip it instead of crashing -
+            # it will be re-parented on the next sync if still needed.
+            logging.warning(
+                f"Cannot move asset {entity.get('name')}: "
+                "folder not found in AYON"
+            )
+            continue
 
         desired_parent_id = _ensure_asset_type_folder(
             project_name,

--- a/services/processor/processor/utils.py
+++ b/services/processor/processor/utils.py
@@ -1,7 +1,40 @@
 """ utils shared between fullsync.py and update_from_kitsu.py """
 
+from typing import Iterable, Optional
+
 import ayon_api
 import gazu
+
+
+def get_ayon_folders_by_kitsu_ids(
+    project_name: str,
+    kitsu_ids: set[str],
+    folder_types: Optional[Iterable[str]] = None,
+) -> dict[str, dict]:
+    """Find AYON folders by their stored Kitsu ids.
+
+    Args:
+        project_name: The name of the AYON project.
+        kitsu_ids: Kitsu ids of the folders to find.
+        folder_types: An optional iterable of folder types to filter by.
+
+    Returns:
+        Mapping of kitsuId -> AYON folder dict for ids that were found.
+    """
+    result: dict[str, dict] = {}
+    for folder in ayon_api.get_folders(
+        project_name,
+        folder_types=folder_types,
+        fields={"id", "name", "parentId", "folderType", "data"},
+    ):
+        folder_kitsu_id = (folder.get("data") or {}).get("kitsuId")
+        if folder_kitsu_id in kitsu_ids:
+            result[folder_kitsu_id] = folder
+
+            # Stop if we have found all the folders we need
+            if len(result) == len(kitsu_ids):
+                break
+    return result
 
 
 def get_asset_types(kitsu_project_id: str) -> dict[str, str]:

--- a/services/processor/processor/utils.py
+++ b/services/processor/processor/utils.py
@@ -15,12 +15,12 @@ def get_ayon_folders_by_kitsu_ids(
     """Find AYON folders by their stored Kitsu ids.
 
     Args:
-        project_name: The name of the AYON project.
-        kitsu_ids: Kitsu ids of the folders to find.
-        folder_types: An optional iterable of folder types to filter by.
+        project_name (str): The name of the AYON project.
+        kitsu_ids (set[str]): Kitsu ids of the folders to find.
+        folder_types (Optional[Iterable[str]]): An optional iterable of folder types to filter by.
 
     Returns:
-        Mapping of kitsuId -> AYON folder dict for ids that were found.
+        dict[str, dict]: Mapping of kitsuId -> AYON folder dict for ids that were found.
     """
     result: dict[str, dict] = {}
     for folder in ayon_api.get_folders(
@@ -47,13 +47,13 @@ def _ensure_asset_type_folder(
     """Return the AYON folder id for an asset type, creating it if needed.
 
     Args:
-        project_name: The name of the AYON project.
-        entity_type_id: The Kitsu entity type id.
-        asset_type_name: The name of the asset type.
-        folders_by_kitsu_id: A dictionary of AYON folders by Kitsu id.
+        project_name (str): The name of the AYON project.
+        entity_type_id (str): The Kitsu entity type id.
+        asset_type_name (str): The name of the asset type.
+        folders_by_kitsu_id (dict): A dictionary of AYON folders by Kitsu id.
 
     Returns:
-        The AYON folder id for the asset type.
+        str: The AYON folder id for the asset type.
     """
     asset_type_folder = folders_by_kitsu_id.get(entity_type_id)
     if asset_type_folder:
@@ -91,8 +91,8 @@ def move_folders_by_asset_type(
     asset-type folders in place even if they become empty.
 
     Args:
-        project_name: The name of the AYON project.
-        entities: List of kitsu entities to process.
+        project_name (str): The name of the AYON project.
+        entities (list[dict[str, Any]]): List of kitsu entities to process.
     """
     entities_ids: set[str] = {"asset"}
     for entity in entities:

--- a/services/processor/pyproject.toml
+++ b/services/processor/pyproject.toml
@@ -9,7 +9,7 @@ package-mode = false
 python = "^3.11"
 gazu = "^0.9.9"
 nxtools = "^1.6"
-ayon-python-api = "1.0.0rc3"
+ayon-python-api = "^1.2.22"
 
 [build-system]
 requires = ["poetry-core>=1.0.0"]


### PR DESCRIPTION
## Changelog Description
Fix folder re-parenting when kitsu asset type is changed.

## Additional review information

Had to bump the `ayon_api` version in `pyproject.toml` to access `update_folder`.

## Testing notes:
1. In you kitsu project, change asset type of an `Asset` entity
2. Start processor, wait for full sync to finish, folder has been moved accordingly
3. While the listener is running, change asset type of an `Asset` entity
4. Check the folder has been moved accordingly
