### PR TITLE
Fix: explain missing server setting

### DIFF
--- a/client/ayon_kitsu/addon.py
+++ b/client/ayon_kitsu/addon.py
@@ -67,6 +67,13 @@ class KitsuAddon(AYONAddon, IPluginPaths, ITrayAction):
     def ensure_is_process_ready(self, process_context):
         """Block process launch if Kitsu credentials are missing or invalid."""
         from ayon_core.addon import ProcessPreparationError
+
+        if not self.server_url:
+            raise ProcessPreparationError(
+                "Kitsu server is not configured. Set the Kitsu Server "
+                "value in AYON Studio Settings before launching a host."
+            )
+
         from .credentials import (
             load_credentials,
             validate_credentials,


### PR DESCRIPTION
## Summary

Adds an explicit Kitsu Server preflight during host process preparation.

## Root cause

`ensure_is_process_ready` passed an empty `self.server_url` to Gazú credential validation. Gazú raised `HostException`, which AYON handled as an unexpected exception.

## Change

When Kitsu Server is not configured, the add-on now raises `ProcessPreparationError` with Studio Settings guidance before Gazu is invoked.

## User impact

A missing Kitsu Server still blocks host launch while Kitsu is enabled, but the user receives a clear configuration message instead of a traceback.


Fixes #140.
